### PR TITLE
Support proxy-only relay transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kind: WireKubeMesh
 metadata:
   name: default
 spec:
-  meshCIDR: "100.64.0.0/10"   # recommended CGNAT range
+  meshCIDR: "172.31.240.0/20" # example only; choose a non-overlapping private range
   autoAllowedIPs:
     includeNodeInternalIP: true  # optionally also publish each node's private IP
 ```

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -179,7 +179,7 @@ func main() {
 		}
 	}()
 
-	a := agentpkg.NewAgent(log, k8sClient, engine, nodeName, podName, podNamespace)
+	a := agentpkg.NewAgent(log, k8sClient, engine, nodeName, podName, podNamespace, restConfig.Host)
 	ctx := ctrl.SetupSignalHandler()
 
 	// Start the WireKubeExternalPeer reconciler in a sibling controller-

--- a/config/agent/servicemonitor.yaml
+++ b/config/agent/servicemonitor.yaml
@@ -5,9 +5,11 @@ metadata:
   namespace: wirekube-system
   labels:
     app: wirekube-agent
+    app.kubernetes.io/name: wirekube-agent
+    app.kubernetes.io/component: agent
 spec:
   selector:
-    app: wirekube-agent
+    app.kubernetes.io/name: wirekube-agent
   ports:
     - name: metrics
       port: 9090

--- a/config/crd/wirekube.io_wirekubeexternalpeers.yaml
+++ b/config/crd/wirekube.io_wirekubeexternalpeers.yaml
@@ -108,9 +108,9 @@ spec:
                 type: integer
               publicKey:
                 description: |-
-                  PublicKey is the external client's WireGuard public key. Issuance tooling
-                  generates the keypair locally and stores only the public half in the
-                  cluster; the private key is printed once and is never persisted.
+                  PublicKey is the external client's WireGuard public key. The
+                  WireKubeExternalPeer stores only the public half; issuance frontends that
+                  support later downloads may persist the rendered client config separately.
                 maxLength: 44
                 minLength: 44
                 type: string

--- a/config/crd/wirekube.io_wirekubemeshes.yaml
+++ b/config/crd/wirekube.io_wirekubemeshes.yaml
@@ -102,7 +102,9 @@ spec:
                   (derived from a hash of the node name), which becomes the sole AllowedIPs entry
                   for that peer. This address is assigned to the WireGuard interface and is used
                   for all intra-mesh traffic — completely independent of the node's physical IP.
-                  Recommended: "100.64.0.0/10" (CGNAT range, RFC 6598, ~4M addresses).
+                  Choose a CIDR that does not overlap with node, pod, service, VPC, proxy,
+                  or corporate networks. Small RFC1918 ranges are usually safer than public
+                  or already-routed infrastructure ranges.
                 pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$
                 type: string
               mtu:

--- a/config/examples/eks-hybrid/daemonset.yaml
+++ b/config/examples/eks-hybrid/daemonset.yaml
@@ -3,13 +3,12 @@
 #
 # Runs on every node (cloud + hybrid) with hostNetwork: true.
 #
-# IMPORTANT: Set KUBERNETES_SERVICE_HOST/PORT to the EKS public API endpoint.
+# IMPORTANT: Set WIREKUBE_KUBE_APISERVER to the EKS public API endpoint.
 # Hybrid nodes cannot reach the ClusterIP (172.16.0.1) before CNI is ready,
 # and the agent needs API access at startup to create its WireKubePeer CR.
 #
-# Replace the KUBERNETES_SERVICE_HOST value with your EKS cluster endpoint:
+# Replace the WIREKUBE_KUBE_APISERVER value with your EKS cluster endpoint:
 #   aws eks describe-cluster --name <CLUSTER> --query cluster.endpoint --output text
-#   → strip "https://" prefix
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -17,6 +16,8 @@ metadata:
   namespace: wirekube-system
   labels:
     app: wirekube-agent
+    app.kubernetes.io/name: wirekube-agent
+    app.kubernetes.io/component: agent
 spec:
   selector:
     matchLabels:
@@ -29,6 +30,8 @@ spec:
     metadata:
       labels:
         app: wirekube-agent
+        app.kubernetes.io/name: wirekube-agent
+        app.kubernetes.io/component: agent
     spec:
       serviceAccountName: wirekube-agent
       hostNetwork: true
@@ -77,10 +80,8 @@ spec:
             - name: WIREKUBE_INTERFACE
               value: "wire_kube"
             # EKS public API endpoint (required for hybrid nodes)
-            - name: KUBERNETES_SERVICE_HOST
-              value: "REPLACE_WITH_EKS_API_ENDPOINT"  # e.g. XXXXX.gr7.ap-northeast-2.eks.amazonaws.com
-            - name: KUBERNETES_SERVICE_PORT
-              value: "443"
+            - name: WIREKUBE_KUBE_APISERVER
+              value: "https://REPLACE_WITH_EKS_API_ENDPOINT"  # e.g. https://XXXXX.gr7.ap-northeast-2.eks.amazonaws.com
           securityContext:
             capabilities:
               add: ["NET_ADMIN", "SYS_MODULE"]

--- a/config/examples/eks-hybrid/wirekubemesh.yaml
+++ b/config/examples/eks-hybrid/wirekubemesh.yaml
@@ -3,13 +3,10 @@
 #
 # Key configuration choices:
 #
-#   autoAllowedIPs (node-internal-ip):
-#     Automatically sets AllowedIPs to <InternalIP>/32 for new peers.
-#     Cloud nodes use VPC IPs; hybrid nodes use their on-prem private IPs.
-#
-#   podCIDRRouting (enabled):
-#     Appends Node.Spec.PodCIDR to AllowedIPs. Only Cilium hybrid nodes
-#     have this field; VPC CNI cloud nodes do not and are safely skipped.
+#   meshCIDR + autoAllowedIPs.includeNodeInternalIP:
+#     Assigns a deterministic mesh /32 and appends <InternalIP>/32 for each
+#     peer. The InternalIP route lets kube-apiserver -> kubelet/logs/exec
+#     traffic traverse WireKube when hybrid node IPs are not directly reachable.
 #
 #   relay (auto, external):
 #     Tries direct P2P first (STUN endpoint discovery), falls back to
@@ -34,15 +31,15 @@ spec:
   listenPort: 51822
   interfaceName: wire_kube
   mtu: 1420
+  # Example only. Replace with a private range that does not overlap with node,
+  # pod, service, VPC, proxy, or corporate networks.
+  meshCIDR: 172.31.240.0/20
   stunServers:
     - stun.cloudflare.com:3478
     - stun.l.google.com:19302
 
   autoAllowedIPs:
-    strategy: node-internal-ip
-
-  podCIDRRouting:
-    enabled: true
+    includeNodeInternalIP: true
 
   natTraversal:
     birthdayAttack: enabled

--- a/config/examples/http-proxy-node/daemonset.yaml
+++ b/config/examples/http-proxy-node/daemonset.yaml
@@ -1,17 +1,33 @@
 ---
+# WireKube Agent DaemonSet for nodes that can reach the relay/apiserver only
+# through an HTTP CONNECT proxy.
+#
+# Usage:
+#   1. Label proxy-only nodes:
+#        kubectl label node <node> wirekube.io/proxy-node=true
+#   2. If the normal agent is already running on that node, delete that pod so
+#      the default DaemonSet does not keep managing the newly labeled node:
+#        kubectl -n wirekube-system delete pod -l app=wirekube-agent \
+#          --field-selector spec.nodeName=<node>
+#   3. Replace REPLACE_WITH_* values below.
+#   4. Apply this manifest in addition to config/agent/rbac.yaml.
+#
+# The default config/agent/daemonset.yaml excludes wirekube.io/proxy-node=true
+# nodes so proxy settings do not leak onto ordinary nodes.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: wirekube-agent
+  name: wirekube-agent-proxy
   namespace: wirekube-system
   labels:
-    app: wirekube-agent
+    app: wirekube-agent-proxy
     app.kubernetes.io/name: wirekube-agent
     app.kubernetes.io/component: agent
+    app.kubernetes.io/variant: proxy
 spec:
   selector:
     matchLabels:
-      app: wirekube-agent
+      app: wirekube-agent-proxy
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -19,9 +35,10 @@ spec:
   template:
     metadata:
       labels:
-        app: wirekube-agent
+        app: wirekube-agent-proxy
         app.kubernetes.io/name: wirekube-agent
         app.kubernetes.io/component: agent
+        app.kubernetes.io/variant: proxy
     spec:
       serviceAccountName: wirekube-agent
       hostNetwork: true
@@ -35,19 +52,19 @@ spec:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: wirekube.io/proxy-node
-                    operator: NotIn
+                    operator: In
                     values:
                       - "true"
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app: wirekube-agent-proxy
+                  app: wirekube-agent
               topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 30
       containers:
         - name: agent
-          image: inerplat/wirekube:v0.0.8-dev.15
+          image: inerplat/wirekube:latest
           command: ["wirekube-agent"]
           args:
             - --node-name=$(NODE_NAME)
@@ -66,25 +83,24 @@ spec:
                   fieldPath: metadata.namespace
             - name: WIREKUBE_INTERFACE
               value: "wire_kube"
-            # Do not put HTTP_PROXY/HTTPS_PROXY here for clusters where only a
-            # subset of nodes needs egress proxying. Label those nodes with
-            # wirekube.io/proxy-node=true and deploy the dedicated proxy-node
-            # example manifest instead.
-            #
-            # Bootstrap-only Kubernetes API override for nodes that cannot reach
-            # the in-cluster Service IP before WireKube routes exist:
-            # - name: WIREKUBE_KUBE_APISERVER
-            #   value: "https://YOUR_KUBE_APISERVER_ENDPOINT"
+            # Bootstrap Kubernetes API endpoint. This must be reachable through
+            # HTTPS_PROXY before WireKube routes exist.
+            - name: WIREKUBE_KUBE_APISERVER
+              value: "https://REPLACE_WITH_KUBE_APISERVER_ENDPOINT"
+            # Relay TCP connections use the HTTP CONNECT proxy for this node.
+            - name: WIREKUBE_RELAY_PROXY
+              value: "environment"
+            - name: HTTPS_PROXY
+              value: "http://REPLACE_WITH_PROXY_HOST:3128"
+            - name: HTTP_PROXY
+              value: "http://REPLACE_WITH_PROXY_HOST:3128"
+            # Keep local and in-cluster destinations direct. Do not include the
+            # apiserver or relay host here when those are reachable only through
+            # the proxy.
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,.svc,.cluster.local,10.96.0.0/12,10.244.0.0/16"
           securityContext:
-            # privileged is required to open /dev/net/tun on Ubuntu 24.04+
-            # hosts where containerd's default device cgroup denies TUN
-            # write even with CAP_NET_ADMIN. Older distros with permissive
-            # device cgroups could get by with capabilities alone, but the
-            # userspace engine needs the TUN device on every node so we
-            # enable privileged here.
             privileged: true
-            # Unconfined AppArmor: the default containerd profile denies
-            # TUN-related operations on Ubuntu 24.04.
             appArmorProfile:
               type: Unconfined
             capabilities:

--- a/config/examples/wirekubemesh-auto-allowedips.yaml
+++ b/config/examples/wirekubemesh-auto-allowedips.yaml
@@ -5,9 +5,10 @@
 # kubectl patch each WireKubePeer after node join.
 #
 # Behavior:
-#   - autoAllowedIPs.strategy=node-internal-ip: if AllowedIPs is currently
-#     empty, the agent auto-sets it to <Node.Status.InternalIP>/32.
-#   - If AllowedIPs is already set (manually or previously), it is NOT overwritten.
+#   - meshCIDR assigns every peer a deterministic overlay /32.
+#   - autoAllowedIPs.includeNodeInternalIP appends <Node.Status.InternalIP>/32
+#     so kube-apiserver -> kubelet/logs/exec traffic can route through WireKube
+#     when the physical node IP is not directly reachable.
 #
 # kubectl apply -f config/examples/wirekubemesh-auto-allowedips.yaml
 apiVersion: wirekube.io/v1alpha1
@@ -18,8 +19,11 @@ spec:
   listenPort: 51822
   interfaceName: wire_kube
   mtu: 1420
+  # Example only. Replace with a private range that does not overlap with node,
+  # pod, service, VPC, proxy, or corporate networks.
+  meshCIDR: 172.31.240.0/20
   stunServers:
     - stun.cloudflare.com:3478
     - stun.l.google.com:19302
   autoAllowedIPs:
-    strategy: node-internal-ip
+    includeNodeInternalIP: true

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -13,7 +13,7 @@ spec:
   listenPort: 51820
   interfaceName: wire_kube
   mtu: 1420
-  meshCIDR: "100.64.0.0/10"            # recommended — deterministic overlay IPs
+  meshCIDR: "172.31.240.0/20"          # example only; choose a non-overlapping private range
   autoAllowedIPs:
     includeNodeInternalIP: true         # optionally also publish each node's private IP
   stunServers:
@@ -40,7 +40,7 @@ spec:
 | `spec.listenPort` | int | `51820` | WireGuard UDP listen port |
 | `spec.interfaceName` | string | `wire_kube` | WireGuard network interface name |
 | `spec.mtu` | int | `1420` | Interface MTU (1420 accounts for WireGuard overhead) |
-| `spec.meshCIDR` | string | - | Private CIDR for the overlay. Each node is automatically assigned a stable `/32` within this range derived from `fnv32a(nodeName)`, and that IP becomes the peer's primary AllowedIPs entry. Use `100.64.0.0/10` (CGNAT, RFC 6598) unless it conflicts with your network. Leave empty to manage AllowedIPs entirely by hand. |
+| `spec.meshCIDR` | string | - | Private CIDR for the overlay. Each node is automatically assigned a stable `/32` within this range derived from `fnv32a(nodeName)`, and that IP becomes the peer's primary AllowedIPs entry. Choose a range that does not overlap with node, pod, service, VPC, proxy, or corporate networks. Leave empty to manage AllowedIPs entirely by hand. |
 | `spec.autoAllowedIPs.includeNodeInternalIP` | bool | `false` | When `true`, also append the node's **private** address to its peer entry so legacy references by node IP still tunnel. The agent never publishes a public IP even if kubelet reports one as `Node.InternalIP` (common on Oracle Cloud / NCloud); set the `wirekube.io/internal-ip` annotation on the Node to force a specific private address. |
 | `spec.stunServers` | []string | - | STUN servers for endpoint discovery. **Minimum 2 required** for Symmetric NAT detection (RFC 5780). |
 | `spec.relay.mode` | string | `auto` | `auto`, `always`, or `never` |

--- a/docs/guides/eks-hybrid-nodes.md
+++ b/docs/guides/eks-hybrid-nodes.md
@@ -269,17 +269,17 @@ kubectl get svc wirekube-relay -n wirekube-system -w
 
 ### Agent DaemonSet
 
-Update `KUBERNETES_SERVICE_HOST` with your EKS API endpoint, then deploy:
+Update `WIREKUBE_KUBE_APISERVER` with your EKS API endpoint, then deploy:
 
 ```bash
 EKS_ENDPOINT=$(aws eks describe-cluster --name <CLUSTER> \
-  --query 'cluster.endpoint' --output text | sed 's|https://||')
+  --query 'cluster.endpoint' --output text)
 
-echo "Set KUBERNETES_SERVICE_HOST to: ${EKS_ENDPOINT}"
+echo "Set WIREKUBE_KUBE_APISERVER to: ${EKS_ENDPOINT}"
 kubectl apply -f config/examples/eks-hybrid/daemonset.yaml
 ```
 
-!!! note "Why KUBERNETES_SERVICE_HOST?"
+!!! note "Why WIREKUBE_KUBE_APISERVER?"
     Hybrid nodes cannot reach the Kubernetes service ClusterIP before CNI
     is ready. The agent needs API access at startup to create its
     WireKubePeer CRD. The EKS public endpoint bypasses this dependency.

--- a/docs/guides/local-playground.md
+++ b/docs/guides/local-playground.md
@@ -328,11 +328,12 @@ spec:
   listenPort: 51822
   interfaceName: wire_kube
   mtu: 1420
+  meshCIDR: 172.31.240.0/20
   stunServers:
     - stun.cloudflare.com:3478
     - stun.l.google.com:19302
   autoAllowedIPs:
-    strategy: node-internal-ip
+    includeNodeInternalIP: true
 EOF
 ```
 

--- a/docs/guides/wsl2-gpu-node.md
+++ b/docs/guides/wsl2-gpu-node.md
@@ -352,11 +352,12 @@ spec:
   listenPort: 51822
   interfaceName: wire_kube
   mtu: 1420
+  meshCIDR: 172.31.240.0/20
   stunServers:
     - stun.cloudflare.com:3478
     - stun.l.google.com:19302
   autoAllowedIPs:
-    strategy: node-internal-ip
+    includeNodeInternalIP: true
   relay:
     mode: auto
     provider: managed

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -55,8 +55,8 @@ kubectl get wirekubemesh default -o yaml
 ## Agent Logs
 
 ```bash
-kubectl logs -n wirekube-system -l app=wirekube-agent --tail=50
-kubectl logs -n wirekube-system -l app=wirekube-agent \
+kubectl logs -n wirekube-system -l app.kubernetes.io/name=wirekube-agent --tail=50
+kubectl logs -n wirekube-system -l app.kubernetes.io/name=wirekube-agent \
   --field-selector spec.nodeName=<node-name> --tail=100
 ```
 
@@ -79,7 +79,9 @@ Key log messages:
 
 The agent exposes Prometheus metrics on `:9090/metrics`. Use the provided
 ServiceMonitor (`config/agent/servicemonitor.yaml`) for Prometheus Operator
-auto-discovery.
+auto-discovery. It selects `app.kubernetes.io/name=wirekube-agent`, so the
+standard agent DaemonSet and the proxy-node agent DaemonSet are scraped by the
+same ServiceMonitor.
 
 ### Available Metrics
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -369,7 +369,7 @@ kubectl -n wirekube-system rollout restart ds/wirekube-agent
 | `ip rule show` | Routing policy (check fwmark 0x574B) |
 | `ss -tnp \| grep 3478` | Relay TCP connection status |
 | `kubectl get wirekubepeers -o wide` | All peer CRDs |
-| `kubectl logs -n wirekube-system -l app=wirekube-agent` | Agent logs |
+| `kubectl logs -n wirekube-system -l app.kubernetes.io/name=wirekube-agent` | Agent logs |
 | `tcpdump -i wire_kube -n` | WireGuard decrypted traffic |
 | `tcpdump -i eth0 udp port 51820` | WireGuard encrypted packets |
 | `cat /proc/sys/net/ipv4/conf/wire_kube/disable_xfrm` | xfrm bypass status |

--- a/docs/reference/crds.md
+++ b/docs/reference/crds.md
@@ -20,7 +20,7 @@ spec:
   listenPort: 51820
   interfaceName: wire_kube
   mtu: 1420
-  meshCIDR: "100.64.0.0/10"        # CGNAT range — each node gets a deterministic /32
+  meshCIDR: "172.31.240.0/20"      # example only; choose a non-overlapping private range
   autoAllowedIPs:
     includeNodeInternalIP: true     # also publish each node's private IP (never public)
   stunServers:
@@ -49,7 +49,7 @@ spec:
 | `listenPort` | int | No | `51820` | WireGuard UDP listen port on each node |
 | `interfaceName` | string | No | `wire_kube` | Name of the WireGuard network interface |
 | `mtu` | int | No | `1420` | Interface MTU. 1420 accounts for WireGuard overhead (40B IPv6 or 20B IPv4 + 8B UDP + 32B WG) |
-| `meshCIDR` | string | No | - | Private CIDR used for mesh overlay addresses. Each node gets a deterministic `/32` inside this range, derived from an FNV-1a hash of the node name. The overlay IP becomes the primary AllowedIPs entry and is assigned to the `wire_kube` TUN. Recommended: `100.64.0.0/10` (CGNAT, RFC 6598). When empty, peers use only manually managed AllowedIPs. |
+| `meshCIDR` | string | No | - | Private CIDR used for mesh overlay addresses. Each node gets a deterministic `/32` inside this range, derived from an FNV-1a hash of the node name. The overlay IP becomes the primary AllowedIPs entry and is assigned to the `wire_kube` TUN. Choose a range that does not overlap with node, pod, service, VPC, proxy, or corporate networks. When empty, peers use only manually managed AllowedIPs. |
 | `autoAllowedIPs.includeNodeInternalIP` | bool | No | `false` | When `true`, the agent also appends the node's **private** address to `spec.allowedIPs` (resolved from `Node.status.addresses` first, then from local interfaces as a fallback). Public IPs are never auto-advertised — doing so would hijack SSH / apiserver routes on the next tunnel flap. Operators can override the picked address with the `wirekube.io/internal-ip` annotation on the Node. |
 | `stunServers` | []string | No | - | STUN servers for public endpoint discovery. **Minimum 2 required** — the agent compares mapped ports across servers to detect Symmetric NAT (RFC 5780). |
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/vishvananda/netlink v1.3.0
 	golang.org/x/crypto v0.26.0
+	golang.org/x/net v0.28.0
 	golang.org/x/sys v0.24.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	k8s.io/api v0.30.3
@@ -63,7 +64,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
-	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/term v0.23.0 // indirect

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -39,6 +39,7 @@ type Agent struct {
 	nodeName     string
 	podName      string
 	podNamespace string
+	apiServer    string
 	syncEvery    time.Duration
 
 	relayPool    *agentrelay.Pool
@@ -134,8 +135,13 @@ type peerTrafficSnapshot struct {
 // far above this threshold.
 const meaningfulTrafficDeltaBytes = 512
 
+const (
+	envRelayProxyMode        = "WIREKUBE_RELAY_PROXY"
+	nodeAnnotationRelayProxy = "wirekube.io/relay-proxy"
+)
+
 // NewAgent creates a new Agent.
-func NewAgent(log logr.Logger, k8sClient client.Client, wgMgr wireguard.WGEngine, nodeName, podName, podNamespace string) *Agent {
+func NewAgent(log logr.Logger, k8sClient client.Client, wgMgr wireguard.WGEngine, nodeName, podName, podNamespace, apiServer string) *Agent {
 	a := &Agent{
 		log:                  log,
 		client:               k8sClient,
@@ -143,6 +149,7 @@ func NewAgent(log logr.Logger, k8sClient client.Client, wgMgr wireguard.WGEngine
 		nodeName:             nodeName,
 		podName:              podName,
 		podNamespace:         podNamespace,
+		apiServer:            apiServer,
 		syncEvery:            parseSyncEvery(),
 		peerFirstSeen:        make(map[string]time.Time),
 		relayedPeers:         make(map[string]bool),
@@ -1384,8 +1391,10 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 	copy(pubKey[:], keyBytes)
 
 	wgPort := a.wgMgr.ListenPort()
-	a.log.Info("relay proxy configured", "wgPort", wgPort)
 	a.relayPool = agentrelay.NewPool(endpoint, pubKey, wgPort)
+	proxyMode := a.relayProxyMode(ctx)
+	a.relayPool.SetProxyMode(proxyMode)
+	a.log.Info("relay proxy configured", "wgPort", wgPort, "proxyMode", proxyMode)
 
 	// Inject relay transport into the WG engine BEFORE Connect so that even
 	// if the initial dial fails, the Bind is wired up and ready when the
@@ -1428,6 +1437,39 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 
 	a.log.Info("relay connected", "endpoint", endpoint, "mode", a.relayMode)
 	return nil
+}
+
+func (a *Agent) relayProxyMode(ctx context.Context) agentrelay.ProxyMode {
+	defaultMode := agentrelay.ProxyDisabled
+	if mode, ok := parseRelayProxyMode(os.Getenv(envRelayProxyMode)); ok {
+		defaultMode = mode
+	}
+
+	node := &corev1.Node{}
+	if err := a.client.Get(ctx, client.ObjectKey{Name: a.nodeName}, node); err != nil {
+		a.log.Error(err, "failed to read node relay proxy annotation; using default relay proxy policy", "annotation", nodeAnnotationRelayProxy, "defaultMode", defaultMode)
+		return defaultMode
+	}
+	raw := strings.ToLower(strings.TrimSpace(node.Annotations[nodeAnnotationRelayProxy]))
+	if raw == "" {
+		return defaultMode
+	}
+	if mode, ok := parseRelayProxyMode(raw); ok {
+		return mode
+	}
+	a.log.Info("unknown relay proxy annotation value; using default relay proxy policy", "annotation", nodeAnnotationRelayProxy, "value", raw, "defaultMode", defaultMode)
+	return defaultMode
+}
+
+func parseRelayProxyMode(raw string) (agentrelay.ProxyMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "env", "environment", "enabled", "enable", "true", "on", "proxy":
+		return agentrelay.ProxyFromEnvironment, true
+	case "disabled", "disable", "false", "off", "direct", "none":
+		return agentrelay.ProxyDisabled, true
+	default:
+		return agentrelay.ProxyDisabled, false
+	}
 }
 
 func managedRelayControlEndpoint(namespace string, port int32) string {

--- a/pkg/agent/apiserver_route_linux.go
+++ b/pkg/agent/apiserver_route_linux.go
@@ -3,12 +3,17 @@
 package agent
 
 import (
+	"errors"
 	"net"
 	"net/url"
-	"os"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
+)
+
+const (
+	apiServerRulePriority = 199
+	mainRouteTable        = 254
 )
 
 // ensureAPIServerRoute adds an ip rule that forces API server traffic to use
@@ -21,53 +26,93 @@ import (
 // Rule: to <API_SERVER_IP>/32 lookup main priority 199
 // This sits just below the fwmark rule and above the WK table rule (priority 200).
 func (a *Agent) ensureAPIServerRoute() {
-	apiIP := apiServerIP()
+	apiIP := apiServerIP(a.apiServer)
+
+	rules, err := netlink.RuleList(syscall.AF_INET)
+	if err == nil {
+		hasCurrent, stale := apiserverRulePlan(rules, apiIP)
+		for _, r := range stale {
+			rule := r
+			if err := netlink.RuleDel(&rule); err != nil && !errors.Is(err, syscall.ESRCH) {
+				a.log.Error(err, "failed to remove stale API server ip rule", "rule", rule.String())
+			} else {
+				a.log.Info("stale API server route rule removed", "rule", rule.String())
+			}
+		}
+		if hasCurrent {
+			return
+		}
+	}
+
 	if apiIP == nil {
 		return
 	}
 
 	rule := netlink.NewRule()
 	rule.Dst = &net.IPNet{IP: apiIP, Mask: net.CIDRMask(32, 32)}
-	rule.Table = 254 // main
-	rule.Priority = 199
+	rule.Table = mainRouteTable
+	rule.Priority = apiServerRulePriority
 
-	// Check if rule already exists.
-	rules, err := netlink.RuleList(syscall.AF_INET)
-	if err == nil {
-		for _, r := range rules {
-			if r.Dst != nil && r.Dst.IP.Equal(apiIP) && r.Table == 254 && r.Priority == 199 {
+	if err := netlink.RuleAdd(rule); err != nil {
+		if rules, listErr := netlink.RuleList(syscall.AF_INET); listErr == nil {
+			if hasCurrent, _ := apiserverRulePlan(rules, apiIP); hasCurrent {
 				return
 			}
 		}
-	}
-
-	if err := netlink.RuleAdd(rule); err != nil {
 		a.log.Error(err, "failed to add API server ip rule", "ip", apiIP)
 	} else {
 		a.log.Info("API server route protected", "ip", apiIP, "rule", "to "+apiIP.String()+"/32 lookup main prio 199")
 	}
 }
 
-// apiServerIP extracts the API server IP from environment or rest config host.
-func apiServerIP() net.IP {
-	// Try KUBERNETES_SERVICE_HOST first (set by kubelet for in-cluster pods).
-	if host := os.Getenv("KUBERNETES_SERVICE_HOST"); host != "" {
-		if ip := net.ParseIP(host); ip != nil {
-			return ip.To4()
+func apiserverRulePlan(rules []netlink.Rule, apiIP net.IP) (bool, []netlink.Rule) {
+	hasCurrent := false
+	stale := []netlink.Rule{}
+	for _, r := range rules {
+		if !isManagedAPIServerRule(r) {
+			continue
 		}
+		if apiIP != nil && r.Dst.IP.Equal(apiIP) {
+			hasCurrent = true
+			continue
+		}
+		stale = append(stale, r)
 	}
+	return hasCurrent, stale
+}
 
-	// Try WIREKUBE_KUBE_APISERVER flag/env.
-	if apiServer := os.Getenv("WIREKUBE_KUBE_APISERVER"); apiServer != "" {
-		return parseHostIP(apiServer)
+func isManagedAPIServerRule(r netlink.Rule) bool {
+	if r.Table != mainRouteTable || r.Priority != apiServerRulePriority {
+		return false
 	}
+	if r.Dst == nil || r.Src != nil || r.Mark != 0 || r.Mask != nil || r.Invert {
+		return false
+	}
+	if r.Tos != 0 || r.TunID != 0 || !isUnsetRuleInt(r.Flow) || r.IifName != "" || r.OifName != "" {
+		return false
+	}
+	if r.Dport != nil || r.Sport != nil || r.IPProto != 0 || r.UIDRange != nil {
+		return false
+	}
+	ones, bits := r.Dst.Mask.Size()
+	return bits == 32 && ones == 32
+}
 
-	return nil
+func isUnsetRuleInt(v int) bool {
+	return v == 0 || v == -1
+}
+
+// apiServerIP extracts the API server IP from the rest config host actually used
+// by this agent. Proxy-node deployments commonly override the in-cluster
+// KUBERNETES_SERVICE_HOST with an external apiserver URL; route protection must
+// follow the effective restConfig.Host, not the ambient kubelet env.
+func apiServerIP(apiServer string) net.IP {
+	return parseHostIP(apiServer)
 }
 
 // isAPIServerCIDR reports whether a CIDR matches the API server IP.
 func (a *Agent) isAPIServerCIDR(cidr string) bool {
-	apiIP := apiServerIP()
+	apiIP := apiServerIP(a.apiServer)
 	if apiIP == nil {
 		return false
 	}

--- a/pkg/agent/apiserver_route_linux_test.go
+++ b/pkg/agent/apiserver_route_linux_test.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package agent
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestAPIServerIPUsesEffectiveRestConfigHost(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "192.0.2.1")
+	t.Setenv("WIREKUBE_KUBE_APISERVER", "https://192.0.2.2:443")
+
+	got := apiServerIP("https://10.0.0.10:6443")
+	if got == nil || got.String() != "10.0.0.10" {
+		t.Fatalf("apiServerIP() = %v, want 10.0.0.10", got)
+	}
+}
+
+func TestAPIServerIPIgnoresHostnames(t *testing.T) {
+	got := apiServerIP("https://cluster.example.com:443")
+	if got != nil {
+		t.Fatalf("apiServerIP() = %v, want nil for hostname apiserver", got)
+	}
+}
+
+func TestAPIServerRulePlanRemovesStaleManagedRule(t *testing.T) {
+	current := apiserverRule("10.0.0.10/32")
+	stale := apiserverRule("192.0.2.10/32")
+	unrelated := apiserverRule("203.0.113.10/32")
+	unrelated.Priority = 32766
+
+	hasCurrent, staleRules := apiserverRulePlan([]netlink.Rule{current, stale, unrelated}, net.ParseIP("10.0.0.10"))
+	if !hasCurrent {
+		t.Fatal("current apiserver rule was not detected")
+	}
+	if len(staleRules) != 1 || !staleRules[0].Dst.IP.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("staleRules = %+v, want only 192.0.2.10/32", staleRules)
+	}
+}
+
+func TestAPIServerRulePlanRemovesAllManagedRulesForHostnameAPIServer(t *testing.T) {
+	rules := []netlink.Rule{
+		apiserverRule("192.0.2.10/32"),
+		apiserverRule("10.0.0.10/32"),
+	}
+
+	hasCurrent, staleRules := apiserverRulePlan(rules, nil)
+	if hasCurrent {
+		t.Fatal("hostname apiserver should not have a current IP rule")
+	}
+	if len(staleRules) != 2 {
+		t.Fatalf("staleRules len = %d, want 2", len(staleRules))
+	}
+}
+
+func TestIsManagedAPIServerRuleRejectsSelectorRule(t *testing.T) {
+	rule := apiserverRule("192.0.2.10/32")
+	rule.Mark = 1234
+	if isManagedAPIServerRule(rule) {
+		t.Fatal("marked rule should not be treated as managed apiserver rule")
+	}
+}
+
+func apiserverRule(cidr string) netlink.Rule {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	r := *netlink.NewRule()
+	r.Table = mainRouteTable
+	r.Priority = apiServerRulePriority
+	r.Dst = ipnet
+	return r
+}

--- a/pkg/agent/relay/client.go
+++ b/pkg/agent/relay/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -42,6 +43,8 @@ type Client struct {
 	relayAddr string
 	myPubKey  [relayproto.PubKeySize]byte
 	wgPort    int
+	proxyMode ProxyMode
+	proxyURL  *url.URL
 
 	mu      sync.RWMutex
 	conn    net.Conn
@@ -61,9 +64,24 @@ func NewClient(relayAddr string, myPubKey [relayproto.PubKeySize]byte, wgPort in
 		relayAddr:   relayAddr,
 		myPubKey:    myPubKey,
 		wgPort:      wgPort,
+		proxyMode:   ProxyDisabled,
 		proxies:     make(map[[relayproto.PubKeySize]byte]*UDPProxy),
 		reconnectCh: make(chan struct{}, 1),
 	}
+}
+
+func (c *Client) SetProxyMode(mode ProxyMode) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.proxyMode = mode.normalized()
+	c.proxyURL = nil
+}
+
+func (c *Client) SetProxyURL(proxyURL *url.URL) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.proxyMode = ProxyExplicit
+	c.proxyURL = proxyURL
 }
 
 // IsConnected returns whether the relay TCP connection is alive.
@@ -101,7 +119,11 @@ func (c *Client) dial(ctx context.Context) error {
 		Timeout: dialTimeout,
 		Control: dialControl,
 	}
-	conn, err := dialer.DialContext(ctx, "tcp", c.relayAddr)
+	c.mu.RLock()
+	proxyMode := c.proxyMode
+	proxyURL := c.proxyURL
+	c.mu.RUnlock()
+	conn, err := dialRelay(ctx, &dialer, c.relayAddr, proxyMode, proxyURL)
 	if err != nil {
 		return fmt.Errorf("connecting to relay %s: %w", c.relayAddr, err)
 	}

--- a/pkg/agent/relay/dial.go
+++ b/pkg/agent/relay/dial.go
@@ -1,0 +1,203 @@
+package relay
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+var relayProxyFromEnvironment = proxyURLFromEnvironment
+
+type ProxyMode string
+
+const (
+	ProxyFromEnvironment ProxyMode = "environment"
+	ProxyDisabled        ProxyMode = "disabled"
+	ProxyExplicit        ProxyMode = "explicit"
+)
+
+func (m ProxyMode) normalized() ProxyMode {
+	switch m {
+	case ProxyFromEnvironment:
+		return ProxyFromEnvironment
+	case ProxyExplicit:
+		return ProxyExplicit
+	default:
+		return ProxyDisabled
+	}
+}
+
+func dialRelay(ctx context.Context, dialer *net.Dialer, relayAddr string, mode ProxyMode, explicitProxyURL *url.URL) (net.Conn, error) {
+	switch mode.normalized() {
+	case ProxyDisabled:
+		return dialer.DialContext(ctx, "tcp", relayAddr)
+	case ProxyExplicit:
+		if explicitProxyURL == nil {
+			return nil, fmt.Errorf("explicit relay proxy mode requires a proxy URL")
+		}
+		return dialRelayViaHTTPProxy(ctx, dialer, relayAddr, explicitProxyURL)
+	default:
+		proxyURL, err := relayProxyFromEnvironment(relayAddr)
+		if err != nil {
+			return nil, err
+		}
+		if proxyURL == nil {
+			return dialer.DialContext(ctx, "tcp", relayAddr)
+		}
+		return dialRelayViaHTTPProxy(ctx, dialer, relayAddr, proxyURL)
+	}
+}
+
+func proxyURLFromEnvironment(relayAddr string) (*url.URL, error) {
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+
+	// Prefer HTTPS_PROXY for relay traffic because operators commonly expose
+	// proxy-reachable relays on TCP/443. Fall back to HTTP_PROXY so nodes that
+	// only provide a generic HTTP proxy can still tunnel relay TCP with CONNECT.
+	proxyURL, err := proxyFunc(&url.URL{Scheme: "https", Host: relayAddr})
+	if err != nil || proxyURL != nil {
+		return proxyURL, err
+	}
+	return proxyFunc(&url.URL{Scheme: "http", Host: relayAddr})
+}
+
+func dialRelayViaHTTPProxy(ctx context.Context, dialer *net.Dialer, relayAddr string, proxyURL *url.URL) (net.Conn, error) {
+	if _, _, err := net.SplitHostPort(relayAddr); err != nil {
+		return nil, fmt.Errorf("relay address %q must be host:port for HTTP CONNECT: %w", relayAddr, err)
+	}
+	proxyAddr, err := proxyDialAddr(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := dialProxy(ctx, dialer, proxyAddr, proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to relay proxy %s: %w", redactedProxyURL(proxyURL), err)
+	}
+
+	clearDeadline, err := setConnDeadline(ctx, conn, dialTimeout)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	defer clearDeadline()
+
+	br := bufio.NewReader(conn)
+	bw := bufio.NewWriter(conn)
+	if err := writeConnectRequest(bw, relayAddr, proxyURL); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("reading proxy CONNECT response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		conn.Close()
+		return nil, fmt.Errorf("proxy CONNECT %s via %s failed: %s", relayAddr, redactedProxyURL(proxyURL), resp.Status)
+	}
+
+	if br.Buffered() > 0 {
+		return &bufferedConn{Conn: conn, r: br}, nil
+	}
+	return conn, nil
+}
+
+func dialProxy(ctx context.Context, dialer *net.Dialer, proxyAddr string, proxyURL *url.URL) (net.Conn, error) {
+	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+	if proxyURL.Scheme != "https" {
+		return conn, nil
+	}
+	tlsConn := tls.Client(conn, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: proxyURL.Hostname(),
+	})
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}
+
+func proxyDialAddr(proxyURL *url.URL) (string, error) {
+	switch proxyURL.Scheme {
+	case "http", "https":
+	default:
+		return "", fmt.Errorf("unsupported relay proxy scheme %q", proxyURL.Scheme)
+	}
+	host := proxyURL.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("relay proxy URL %q has no host", redactedProxyURL(proxyURL))
+	}
+	port := proxyURL.Port()
+	if port == "" {
+		if proxyURL.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+func writeConnectRequest(w *bufio.Writer, relayAddr string, proxyURL *url.URL) error {
+	if _, err := fmt.Fprintf(w, "CONNECT %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: wirekube-agent\r\nProxy-Connection: Keep-Alive\r\n", relayAddr, relayAddr); err != nil {
+		return err
+	}
+	if proxyURL.User != nil {
+		password, _ := proxyURL.User.Password()
+		token := base64.StdEncoding.EncodeToString([]byte(proxyURL.User.Username() + ":" + password))
+		if _, err := fmt.Fprintf(w, "Proxy-Authorization: Basic %s\r\n", token); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(w, "\r\n"); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func setConnDeadline(ctx context.Context, conn net.Conn, timeout time.Duration) (func(), error) {
+	deadline := time.Now().Add(timeout)
+	if dl, ok := ctx.Deadline(); ok && dl.Before(deadline) {
+		deadline = dl
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		return nil, fmt.Errorf("setting relay proxy deadline: %w", err)
+	}
+	return func() {
+		_ = conn.SetDeadline(time.Time{})
+	}, nil
+}
+
+func redactedProxyURL(proxyURL *url.URL) string {
+	if proxyURL == nil {
+		return ""
+	}
+	clone := *proxyURL
+	if clone.User != nil {
+		clone.User = url.User(clone.User.Username())
+	}
+	return clone.String()
+}
+
+type bufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *bufferedConn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}

--- a/pkg/agent/relay/dial_test.go
+++ b/pkg/agent/relay/dial_test.go
@@ -1,0 +1,154 @@
+package relay
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestProxyURLFromEnvironmentPrefersHTTPSProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTP_PROXY", "http://http-proxy.example:3128")
+	t.Setenv("HTTPS_PROXY", "http://https-proxy.example:3128")
+
+	got, err := proxyURLFromEnvironment("relay.example.com:443")
+	if err != nil {
+		t.Fatalf("proxyURLFromEnvironment: %v", err)
+	}
+	if got == nil {
+		t.Fatal("proxyURLFromEnvironment returned nil")
+	}
+	if got.String() != "http://https-proxy.example:3128" {
+		t.Fatalf("proxy = %q, want HTTPS proxy", got.String())
+	}
+}
+
+func TestProxyURLFromEnvironmentHonorsNoProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://proxy.example:3128")
+	t.Setenv("NO_PROXY", "relay.example.com")
+
+	got, err := proxyURLFromEnvironment("relay.example.com:443")
+	if err != nil {
+		t.Fatalf("proxyURLFromEnvironment: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("proxy = %q, want nil due to NO_PROXY", got.String())
+	}
+}
+
+func TestProxyModeDefaultsToDisabled(t *testing.T) {
+	if got := (ProxyMode("")).normalized(); got != ProxyDisabled {
+		t.Fatalf("empty proxy mode = %q, want %q", got, ProxyDisabled)
+	}
+
+	var pubKey [32]byte
+	if got := NewClient("relay.example.com:443", pubKey, 51820).proxyMode; got != ProxyDisabled {
+		t.Fatalf("new client proxy mode = %q, want %q", got, ProxyDisabled)
+	}
+	if got := NewPool("relay.example.com:443", pubKey, 51820).proxyMode; got != ProxyDisabled {
+		t.Fatalf("new pool proxy mode = %q, want %q", got, ProxyDisabled)
+	}
+}
+
+func TestDialRelayViaHTTPProxyUsesConnectAndPreservesStream(t *testing.T) {
+	proxy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	seen := make(chan *http.Request, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := proxy.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		seen <- req
+		if _, err := io.WriteString(conn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+			errCh <- err
+			return
+		}
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			errCh <- err
+			return
+		}
+		if string(buf) != "ping" {
+			errCh <- fmt.Errorf("tunnel payload = %q, want ping", string(buf))
+			return
+		}
+		_, err = conn.Write([]byte("pong"))
+		errCh <- err
+	}()
+
+	proxyURL := &url.URL{
+		Scheme: "http",
+		Host:   proxy.Addr().String(),
+		User:   url.UserPassword("agent", "secret"),
+	}
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	conn, err := dialRelayViaHTTPProxy(context.Background(), dialer, "relay.example.com:443", proxyURL)
+	if err != nil {
+		t.Fatalf("dialRelayViaHTTPProxy: %v", err)
+	}
+	defer conn.Close()
+
+	req := <-seen
+	if req.Method != http.MethodConnect {
+		t.Fatalf("CONNECT method = %q", req.Method)
+	}
+	if req.Host != "relay.example.com:443" {
+		t.Fatalf("CONNECT host = %q", req.Host)
+	}
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("agent:secret"))
+	if got := req.Header.Get("Proxy-Authorization"); got != wantAuth {
+		t.Fatalf("Proxy-Authorization = %q, want %q", got, wantAuth)
+	}
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write tunnel payload: %v", err)
+	}
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read tunnel payload: %v", err)
+	}
+	if string(buf) != "pong" {
+		t.Fatalf("tunnel response = %q, want pong", string(buf))
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("proxy handler: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxy handler did not finish")
+	}
+}
+
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY", "REQUEST_METHOD",
+		"http_proxy", "https_proxy", "no_proxy", "all_proxy",
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/pkg/agent/relay/pool.go
+++ b/pkg/agent/relay/pool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"sync"
 	"time"
 
@@ -22,6 +23,8 @@ type Pool struct {
 	relayAddr string
 	myPubKey  [relayproto.PubKeySize]byte
 	wgPort    int
+	proxyMode ProxyMode
+	proxyURL  *url.URL
 
 	mu      sync.RWMutex
 	clients map[string]*Client // keyed by resolved IP:port
@@ -62,8 +65,29 @@ func NewPool(relayAddr string, myPubKey [relayproto.PubKeySize]byte, wgPort int)
 		relayAddr: relayAddr,
 		myPubKey:  myPubKey,
 		wgPort:    wgPort,
+		proxyMode: ProxyDisabled,
 		clients:   make(map[string]*Client),
 		proxies:   make(map[[relayproto.PubKeySize]byte]*UDPProxy),
+	}
+}
+
+func (p *Pool) SetProxyMode(mode ProxyMode) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.proxyMode = mode.normalized()
+	p.proxyURL = nil
+	for _, c := range p.clients {
+		c.SetProxyMode(p.proxyMode)
+	}
+}
+
+func (p *Pool) SetProxyURL(proxyURL *url.URL) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.proxyMode = ProxyExplicit
+	p.proxyURL = proxyURL
+	for _, c := range p.clients {
+		c.SetProxyURL(proxyURL)
 	}
 }
 
@@ -384,7 +408,17 @@ func (p *Pool) connectOne(ctx context.Context, addr string) error {
 		return nil
 	}
 
+	p.mu.RLock()
+	proxyMode := p.proxyMode
+	proxyURL := p.proxyURL
+	p.mu.RUnlock()
+
 	c := NewClient(addr, p.myPubKey, p.wgPort)
+	if proxyMode == ProxyExplicit {
+		c.SetProxyURL(proxyURL)
+	} else {
+		c.SetProxyMode(proxyMode)
+	}
 	c.onData = p.handleData
 	c.onExternal = p.handleExternalData
 	c.onHint = p.handleHint

--- a/pkg/agent/relay_proxy_test.go
+++ b/pkg/agent/relay_proxy_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	agentrelay "github.com/wirekube/wirekube/pkg/agent/relay"
+)
+
+func TestRelayProxyModeFromNodeAnnotation(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		annotation string
+		want       agentrelay.ProxyMode
+	}{
+		{name: "default direct", want: agentrelay.ProxyDisabled},
+		{name: "enabled", annotation: "enabled", want: agentrelay.ProxyFromEnvironment},
+		{name: "environment", annotation: "environment", want: agentrelay.ProxyFromEnvironment},
+		{name: "disabled", annotation: "disabled", want: agentrelay.ProxyDisabled},
+		{name: "direct", annotation: "direct", want: agentrelay.ProxyDisabled},
+		{name: "env enables proxy", env: "environment", want: agentrelay.ProxyFromEnvironment},
+		{name: "annotation disabled overrides env", env: "environment", annotation: "disabled", want: agentrelay.ProxyDisabled},
+		{name: "annotation environment overrides env disabled", env: "disabled", annotation: "environment", want: agentrelay.ProxyFromEnvironment},
+		{name: "unknown falls back to direct default", annotation: "surprise", want: agentrelay.ProxyDisabled},
+		{name: "unknown falls back to env default", env: "environment", annotation: "surprise", want: agentrelay.ProxyFromEnvironment},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envRelayProxyMode, tt.env)
+			annotations := map[string]string{}
+			if tt.annotation != "" {
+				annotations[nodeAnnotationRelayProxy] = tt.annotation
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "worker1",
+					Annotations: annotations,
+				},
+			}
+			c := ctrlclientfake.NewClientBuilder().
+				WithScheme(cleanupTestScheme(t)).
+				WithObjects(node).
+				Build()
+			a := &Agent{
+				log:      testr.New(t),
+				client:   c,
+				nodeName: "worker1",
+			}
+
+			if got := a.relayProxyMode(context.Background()); got != tt.want {
+				t.Fatalf("relayProxyMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelayProxyModeMissingNodeFallsBackToEnvironment(t *testing.T) {
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(cleanupTestScheme(t)).
+		Build()
+	a := &Agent{
+		log:      testr.New(t),
+		client:   c,
+		nodeName: "missing",
+	}
+
+	t.Setenv(envRelayProxyMode, "environment")
+	if got := a.relayProxyMode(context.Background()); got != agentrelay.ProxyFromEnvironment {
+		t.Fatalf("relayProxyMode() = %q, want %q", got, agentrelay.ProxyFromEnvironment)
+	}
+}
+
+func TestRelayProxyModeMissingNodeDefaultsToDirect(t *testing.T) {
+	c := ctrlclientfake.NewClientBuilder().
+		WithScheme(cleanupTestScheme(t)).
+		Build()
+	a := &Agent{
+		log:      testr.New(t),
+		client:   c,
+		nodeName: "missing",
+	}
+
+	if got := a.relayProxyMode(context.Background()); got != agentrelay.ProxyDisabled {
+		t.Fatalf("relayProxyMode() = %q, want %q", got, agentrelay.ProxyDisabled)
+	}
+}

--- a/pkg/api/v1alpha1/wirekubeexternalpeer_types.go
+++ b/pkg/api/v1alpha1/wirekubeexternalpeer_types.go
@@ -79,9 +79,9 @@ type WireKubeExternalPeerSpec struct {
 	// +optional
 	IngressPeer string `json:"ingressPeer,omitempty"`
 
-	// PublicKey is the external client's WireGuard public key. Issuance tooling
-	// generates the keypair locally and stores only the public half in the
-	// cluster; the private key is printed once and is never persisted.
+	// PublicKey is the external client's WireGuard public key. The
+	// WireKubeExternalPeer stores only the public half; issuance frontends that
+	// support later downloads may persist the rendered client config separately.
 	// +kubebuilder:validation:MinLength=44
 	// +kubebuilder:validation:MaxLength=44
 	PublicKey string `json:"publicKey"`

--- a/pkg/api/v1alpha1/wirekubemesh_types.go
+++ b/pkg/api/v1alpha1/wirekubemesh_types.go
@@ -48,7 +48,9 @@ type WireKubeMeshSpec struct {
 	// (derived from a hash of the node name), which becomes the sole AllowedIPs entry
 	// for that peer. This address is assigned to the WireGuard interface and is used
 	// for all intra-mesh traffic — completely independent of the node's physical IP.
-	// Recommended: "100.64.0.0/10" (CGNAT range, RFC 6598, ~4M addresses).
+	// Choose a CIDR that does not overlap with node, pod, service, VPC, proxy,
+	// or corporate networks. Small RFC1918 ranges are usually safer than public
+	// or already-routed infrastructure ranges.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^([0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`
 	MeshCIDR string `json:"meshCIDR,omitempty"`

--- a/pkg/controller/external/reconciler.go
+++ b/pkg/controller/external/reconciler.go
@@ -373,6 +373,9 @@ func (r *Reconciler) resolveNamedIngressPeer(ctx context.Context, cr *wirekubev1
 		defer cancel()
 		got, err := prober.ProbeIngressLatency(probeCtx, [][32]byte{pubKey})
 		if err != nil {
+			if errors.Is(err, ErrIngressProbeDisabled) {
+				return peerName, pubKey, ctrl.Result{}, nil, true
+			}
 			res, retErr := r.markPending(ctx, cr, reasonIngressProbeFailed,
 				fmt.Sprintf("relay ingress probe failed: %v", err), requeueShort)
 			return "", zero, res, retErr, false
@@ -430,6 +433,9 @@ func (r *Reconciler) probeIngressLatencies(ctx context.Context, relayCtl RelayCo
 	defer cancel()
 	got, err := prober.ProbeIngressLatency(probeCtx, keys)
 	if err != nil {
+		if errors.Is(err, ErrIngressProbeDisabled) {
+			return nil, false, nil
+		}
 		return nil, true, err
 	}
 	return got, true, nil

--- a/pkg/controller/external/reconciler_test.go
+++ b/pkg/controller/external/reconciler_test.go
@@ -432,6 +432,47 @@ func TestReconcile_AutoIngressKeepsFastPeerWhenLoadPenaltyIsSmallerThanRTTGap(t 
 	}
 }
 
+func TestReconcile_AutoIngressFallsBackWhenIngressProbeDisabled(t *testing.T) {
+	cr := newExternalPeer(testExternalName)
+	c := newFakeClient(t, cr, newReadyMesh(), newIngressPeer())
+	relayCtl := newProbeRelay(testRelayHost, nil)
+	relayCtl.probeErr = ErrIngressProbeDisabled
+	r := &Reconciler{Client: c, Scheme: testScheme(t), Relay: relayCtl}
+
+	reconcileTwice(t, r, testExternalName)
+
+	got := getCR(t, c, testExternalName)
+	if got.Status.Phase != wirekubev1alpha1.ExternalPeerPhaseActive {
+		t.Fatalf("phase = %q, want Active", got.Status.Phase)
+	}
+	if got.Status.IngressPeerName != testIngressPeer {
+		t.Fatalf("ingressPeerName = %q, want %q", got.Status.IngressPeerName, testIngressPeer)
+	}
+	if relayCtl.probeN.Load() != 1 {
+		t.Fatalf("ProbeIngressLatency calls = %d, want 1", relayCtl.probeN.Load())
+	}
+}
+
+func TestReconcile_ExplicitIngressPeerFallsBackWhenIngressProbeDisabled(t *testing.T) {
+	cr := newExternalPeer(testExternalName, func(p *wirekubev1alpha1.WireKubeExternalPeer) {
+		p.Spec.IngressPeer = "node-a"
+	})
+	c := newFakeClient(t, cr, newReadyMesh(), newIngressPeer())
+	relayCtl := newProbeRelay(testRelayHost, nil)
+	relayCtl.probeErr = ErrIngressProbeDisabled
+	r := &Reconciler{Client: c, Scheme: testScheme(t), Relay: relayCtl}
+
+	reconcileTwice(t, r, testExternalName)
+
+	got := getCR(t, c, testExternalName)
+	if got.Status.Phase != wirekubev1alpha1.ExternalPeerPhaseActive {
+		t.Fatalf("phase = %q, want Active", got.Status.Phase)
+	}
+	if got.Status.IngressPeerName != "node-a" {
+		t.Fatalf("ingressPeerName = %q, want node-a", got.Status.IngressPeerName)
+	}
+}
+
 func TestReconcile_ExplicitIngressPeerMustBeReachableFromRelay(t *testing.T) {
 	nodeAKey := ingressPubKey()
 	if _, err := decodeWGKey(nodeAKey); err != nil {

--- a/pkg/controller/external/relay_controller.go
+++ b/pkg/controller/external/relay_controller.go
@@ -21,6 +21,12 @@ import (
 // mutating calls when no control path is configured.
 var ErrNotImplemented = errors.New("relay controller: not implemented")
 
+// ErrIngressProbeDisabled means the relay data plane is available but the
+// optional ingress-probe control frame is disabled. Shared-endpoint external
+// peers must still be reconciled in this mode; they fall back to peer status
+// and load-based selection.
+var ErrIngressProbeDisabled = errors.New("relay ingress probe disabled")
+
 // RelayController is the surface the reconciler uses to publish the relay
 // endpoint and, for legacy allocations, register or tear down per-peer UDP
 // forwarder mappings on the relay.

--- a/pkg/controller/external/relay_controller_test.go
+++ b/pkg/controller/external/relay_controller_test.go
@@ -278,6 +278,41 @@ func TestFanoutRelayController_ProbeIngressLatencyRequiresEveryReplica(t *testin
 	}
 }
 
+func TestRemoteRelayController_ProbeIngressLatencyDisabled(t *testing.T) {
+	server := startFakeRelayControl(t, 53042)
+	defer server.Close()
+	server.SetProbeError("relay control disabled")
+
+	var key [32]byte
+	_, err := NewRemoteRelayController(server.Addr(), "relay.example.com").ProbeIngressLatency(context.Background(), [][32]byte{key})
+	if !errors.Is(err, ErrIngressProbeDisabled) {
+		t.Fatalf("ProbeIngressLatency error = %v, want ErrIngressProbeDisabled", err)
+	}
+}
+
+func TestFanoutRelayController_ProbeIngressLatencyDisabledFallsBack(t *testing.T) {
+	first := startFakeRelayControl(t, 53042)
+	second := startFakeRelayControl(t, 61000)
+	defer first.Close()
+	defer second.Close()
+	first.SetProbeError("relay control disabled")
+	second.SetProbeError("relay control disabled")
+
+	var key [32]byte
+	c := &FanoutRelayController{endpoint: "relay.example.com"}
+	c.controllersFn = func() []*RemoteRelayController {
+		return []*RemoteRelayController{
+			NewRemoteRelayController(first.Addr(), c.endpoint),
+			NewRemoteRelayController(second.Addr(), c.endpoint),
+		}
+	}
+
+	_, err := c.ProbeIngressLatency(context.Background(), [][32]byte{key})
+	if !errors.Is(err, ErrIngressProbeDisabled) {
+		t.Fatalf("ProbeIngressLatency error = %v, want ErrIngressProbeDisabled", err)
+	}
+}
+
 type fakeRelayControl struct {
 	ln net.Listener
 
@@ -287,6 +322,7 @@ type fakeRelayControl struct {
 	registers    []fakeRelayRegister
 	unregisters  []uint16
 	probeRTTs    map[[32]byte]time.Duration
+	probeErr     string
 	probeReqs    [][][32]byte
 }
 
@@ -337,6 +373,12 @@ func (f *fakeRelayControl) SetProbeLatencies(latencies map[[32]byte]time.Duratio
 	for key, rtt := range latencies {
 		f.probeRTTs[key] = rtt
 	}
+}
+
+func (f *fakeRelayControl) SetProbeError(message string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.probeErr = message
 }
 
 func (f *fakeRelayControl) ProbeRequests() [][][32]byte {
@@ -402,6 +444,12 @@ func (f *fakeRelayControl) handle(conn net.Conn) {
 			return
 		}
 		f.mu.Lock()
+		if f.probeErr != "" {
+			probeErr := f.probeErr
+			f.mu.Unlock()
+			_ = relay.WriteFrame(conn, relay.MakeErrorFrame(probeErr))
+			return
+		}
 		f.probeReqs = append(f.probeReqs, append([][32]byte(nil), keys...))
 		results := make([]relay.IngressProbeResult, 0, len(keys))
 		for _, key := range keys {

--- a/pkg/controller/external/remote_relay_controller.go
+++ b/pkg/controller/external/remote_relay_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -130,7 +131,11 @@ func (c *RemoteRelayController) ProbeIngressLatency(ctx context.Context, ingress
 		return nil, err
 	}
 	if resp.Type == relay.MsgError {
-		return nil, fmt.Errorf("relay refused ingress probe: %s", string(resp.Body))
+		body := string(resp.Body)
+		if strings.Contains(body, "relay control disabled") {
+			return nil, fmt.Errorf("%w: %s", ErrIngressProbeDisabled, body)
+		}
+		return nil, fmt.Errorf("relay refused ingress probe: %s", body)
 	}
 	if resp.Type != relay.MsgIngressProbe {
 		return nil, fmt.Errorf("unexpected response type %#x to ingress probe", resp.Type)
@@ -296,9 +301,14 @@ func (c *FanoutRelayController) ProbeIngressLatency(ctx context.Context, ingress
 	seen := make(map[[32]byte]int, len(ingressPubKeys))
 	maxRTT := make(map[[32]byte]time.Duration, len(ingressPubKeys))
 	var errs []error
+	probeDisabled := false
 	for range controllers {
 		resp := <-responses
 		if resp.err != nil {
+			if errors.Is(resp.err, ErrIngressProbeDisabled) {
+				probeDisabled = true
+				continue
+			}
 			errs = append(errs, fmt.Errorf("relay fanout ingress probe %s: %w", resp.addr, resp.err))
 			continue
 		}
@@ -308,6 +318,9 @@ func (c *FanoutRelayController) ProbeIngressLatency(ctx context.Context, ingress
 				maxRTT[key] = rtt
 			}
 		}
+	}
+	if probeDisabled {
+		return nil, ErrIngressProbeDisabled
 	}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- add relay dialing support for nodes that can only reach the relay through `HTTP_PROXY` / `HTTPS_PROXY`
- split proxy-node scheduling from the default agent DaemonSet so only labeled nodes use the proxy transport path
- add bootstrap Kubernetes API routing support for nodes that cannot reach the in-cluster Service IP before WireKube routes are established
- document the proxy-node flow and add a dedicated example manifest

## Notes

- This PR intentionally does not include the admin web sidecar. That work is split into a separate PR.
- Deployment-specific image tags, node names, and local cluster values are not included.

## Validation

- `GOCACHE=/private/tmp/wirekube-gocache GOMODCACHE=/private/tmp/wirekube-gomodcache go mod tidy`
- `GOCACHE=/private/tmp/wirekube-gocache GOMODCACHE=/private/tmp/wirekube-gomodcache go vet ./...`
- `gofmt -l .`
- `GOCACHE=/private/tmp/wirekube-gocache GOMODCACHE=/private/tmp/wirekube-gomodcache GOOS=linux GOARCH=amd64 go test -c -o /tmp/wirekube-pkg-agent-linux.test ./pkg/agent`
- `GOCACHE=/private/tmp/wirekube-gocache GOMODCACHE=/private/tmp/wirekube-gomodcache sh -c 'go test $(go list ./... | grep -v /test/e2e) -count=1'`
- `GOCACHE=/private/tmp/wirekube-gocache GOMODCACHE=/private/tmp/wirekube-gomodcache sh -c 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/agent/ && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/relay/ && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/wirekubectl/ && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/agent/'`
