### PR TITLE
fix(agent): restrict route-before-handshake to mesh /32; relay + NAT/ICE hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ site/
 /operator
 /wirekubectl
 /stun-server
-internal/
 
 # Test binaries produced by `go test -c`. These are build artifacts
 # that must not be committed (kind_e2e.test is ~48MB).

--- a/cmd/admin-web/main.go
+++ b/cmd/admin-web/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -76,6 +77,13 @@ func main() {
 		log.Fatalf("admin-web auth: %v", err)
 	}
 
+	// Enforce the safe invariant: the console can download private keys, so it
+	// may only run without authentication when bound to loopback. A non-loopback
+	// bind with auth disabled is refused rather than silently exposed.
+	if auth == nil && !isLoopbackAddr(*addr) {
+		log.Fatalf("refusing to start: admin-web is bound to non-loopback address %q with authentication disabled; set WIREKUBE_ADMIN_WEB_USERNAME and WIREKUBE_ADMIN_WEB_PASSWORD_HASH", *addr)
+	}
+
 	s := newServer(c, *waitFor, *secretNamespace)
 	s.auth = auth
 	if auth == nil {
@@ -95,6 +103,21 @@ func main() {
 type basicAuthConfig struct {
 	username     string
 	passwordHash []byte // bcrypt hash of the password
+}
+
+// isLoopbackAddr reports whether a listen address binds only the loopback
+// interface. An empty or wildcard host (":8080", "0.0.0.0:8080") is not
+// loopback — it binds all interfaces — so it returns false.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // loadBasicAuth reads credentials from the environment. Authentication is

--- a/cmd/admin-web/main.go
+++ b/cmd/admin-web/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	qrcode "github.com/skip2/go-qrcode"
+	"golang.org/x/crypto/bcrypt"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,11 +71,49 @@ func main() {
 		log.Fatalf("kubernetes client: %v", err)
 	}
 
+	auth, err := loadBasicAuth()
+	if err != nil {
+		log.Fatalf("admin-web auth: %v", err)
+	}
+
 	s := newServer(c, *waitFor, *secretNamespace)
+	s.auth = auth
+	if auth == nil {
+		log.Printf("WARNING: admin-web authentication is DISABLED; set WIREKUBE_ADMIN_WEB_USERNAME and WIREKUBE_ADMIN_WEB_PASSWORD_HASH to require login")
+	} else {
+		log.Printf("admin-web authentication enabled for user %q", auth.username)
+	}
 	log.Printf("wirekube-admin-web listening on %s", *addr)
 	if err := http.ListenAndServe(*addr, s.routes()); err != nil {
 		log.Fatalf("listen: %v", err)
 	}
+}
+
+// basicAuthConfig holds HTTP Basic Auth credentials sourced from the
+// environment (injected from a Kubernetes Secret). A nil *basicAuthConfig
+// means authentication is disabled.
+type basicAuthConfig struct {
+	username     string
+	passwordHash []byte // bcrypt hash of the password
+}
+
+// loadBasicAuth reads credentials from the environment. Authentication is
+// enabled only when both the username and the bcrypt password hash are set;
+// setting exactly one is treated as a misconfiguration and is rejected so a
+// deploy that intends to require auth never silently runs open.
+func loadBasicAuth() (*basicAuthConfig, error) {
+	user := os.Getenv("WIREKUBE_ADMIN_WEB_USERNAME")
+	hash := os.Getenv("WIREKUBE_ADMIN_WEB_PASSWORD_HASH")
+	if user == "" && hash == "" {
+		return nil, nil
+	}
+	if user == "" || hash == "" {
+		return nil, fmt.Errorf("both WIREKUBE_ADMIN_WEB_USERNAME and WIREKUBE_ADMIN_WEB_PASSWORD_HASH must be set to enable authentication")
+	}
+	if _, err := bcrypt.Cost([]byte(hash)); err != nil {
+		return nil, fmt.Errorf("WIREKUBE_ADMIN_WEB_PASSWORD_HASH is not a valid bcrypt hash: %w", err)
+	}
+	return &basicAuthConfig{username: user, passwordHash: []byte(hash)}, nil
 }
 
 func restConfig(kubeconfig string) (*rest.Config, error) {
@@ -116,6 +155,7 @@ type server struct {
 	client          client.Client
 	waitFor         time.Duration
 	secretNamespace string
+	auth            *basicAuthConfig
 	csrfToken       string
 	waitForActive   func(context.Context, client.Client, string, time.Duration) (*wirekubev1alpha1.WireKubeExternalPeer, error)
 }
@@ -147,14 +187,46 @@ func (s *server) routes() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok\n"))
 	})
-	mux.HandleFunc("/", s.handleIndex)
-	mux.HandleFunc("/relays", s.handleRelays)
-	mux.HandleFunc("/mesh-nodes", s.handleMeshNodes)
-	mux.HandleFunc("/mesh-nodes/", s.handleMeshNodeAction)
-	mux.HandleFunc("/peers", s.handlePeers)
-	mux.HandleFunc("/peers/delete", s.handleBulkDelete)
-	mux.HandleFunc("/peers/", s.handlePeerAction)
+	mux.HandleFunc("/", s.requireAuth(s.handleIndex))
+	mux.HandleFunc("/relays", s.requireAuth(s.handleRelays))
+	mux.HandleFunc("/mesh-nodes", s.requireAuth(s.handleMeshNodes))
+	mux.HandleFunc("/mesh-nodes/", s.requireAuth(s.handleMeshNodeAction))
+	mux.HandleFunc("/peers", s.requireAuth(s.handlePeers))
+	mux.HandleFunc("/peers/delete", s.requireAuth(s.handleBulkDelete))
+	mux.HandleFunc("/peers/", s.requireAuth(s.handlePeerAction))
 	return mux
+}
+
+// requireAuth wraps a handler with HTTP Basic Auth when credentials are
+// configured. When s.auth is nil, authentication is disabled and the handler
+// runs unguarded (the operator was warned at startup). The bcrypt password
+// comparison is run on every request regardless of whether the username
+// matched, so its fixed cost dominates response timing and hides whether the
+// username was correct.
+func (s *server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.auth == nil {
+			next(w, r)
+			return
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			s.challengeAuth(w)
+			return
+		}
+		userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(s.auth.username)) == 1
+		passMatch := bcrypt.CompareHashAndPassword(s.auth.passwordHash, []byte(pass)) == nil
+		if !userMatch || !passMatch {
+			s.challengeAuth(w)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *server) challengeAuth(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="wirekube-admin", charset="UTF-8"`)
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
 }
 
 func (s *server) handleIndex(w http.ResponseWriter, r *http.Request) {

--- a/cmd/admin-web/main_test.go
+++ b/cmd/admin-web/main_test.go
@@ -182,6 +182,28 @@ func TestLoadBasicAuth(t *testing.T) {
 	}
 }
 
+func TestIsLoopbackAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8080", true},
+		{"localhost:8080", true},
+		{"[::1]:8080", true},
+		{":8080", false},        // wildcard: all interfaces
+		{"0.0.0.0:8080", false}, // all interfaces
+		{"10.0.0.5:8080", false},
+		{"garbage", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			if got := isLoopbackAddr(tc.addr); got != tc.want {
+				t.Fatalf("isLoopbackAddr(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIssuePeerRejectsMissingCSRF(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	s := newServer(c, time.Second, "wirekube-system")

--- a/cmd/admin-web/main_test.go
+++ b/cmd/admin-web/main_test.go
@@ -92,6 +92,96 @@ func TestIssuePeerCreatesCRAndReturnsConfig(t *testing.T) {
 	}
 }
 
+func TestBasicAuth(t *testing.T) {
+	// bcrypt hash of "s3cret" (cost 10).
+	const hash = "$2a$10$QUOTjZgtTKnkj9pwIJZOoOCoKP8dWi8dbZ9.wto6FrQNdVFZx1HkO"
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := newServer(c, time.Second, "wirekube-system")
+	s.auth = &basicAuthConfig{username: "admin", passwordHash: []byte(hash)}
+
+	cases := []struct {
+		name       string
+		setAuth    func(*http.Request)
+		wantStatus int
+	}{
+		{"no credentials", func(*http.Request) {}, http.StatusUnauthorized},
+		{"wrong password", func(r *http.Request) { r.SetBasicAuth("admin", "nope") }, http.StatusUnauthorized},
+		{"wrong username", func(r *http.Request) { r.SetBasicAuth("root", "s3cret") }, http.StatusUnauthorized},
+		{"correct", func(r *http.Request) { r.SetBasicAuth("admin", "s3cret") }, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+			tc.setAuth(req)
+			rec := httptest.NewRecorder()
+			s.routes().ServeHTTP(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if tc.wantStatus == http.StatusUnauthorized {
+				if got := rec.Header().Get("WWW-Authenticate"); !strings.HasPrefix(got, "Basic ") {
+					t.Fatalf("WWW-Authenticate = %q, want Basic challenge", got)
+				}
+			}
+		})
+	}
+}
+
+func TestBasicAuthDisabledAllowsAccess(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := newServer(c, time.Second, "wirekube-system") // s.auth == nil
+
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (auth disabled)", rec.Code, http.StatusOK)
+	}
+}
+
+func TestHealthzSkipsAuth(t *testing.T) {
+	const hash = "$2a$10$QUOTjZgtTKnkj9pwIJZOoOCoKP8dWi8dbZ9.wto6FrQNdVFZx1HkO"
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	s := newServer(c, time.Second, "wirekube-system")
+	s.auth = &basicAuthConfig{username: "admin", passwordHash: []byte(hash)}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	s.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("healthz status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestLoadBasicAuth(t *testing.T) {
+	const hash = "$2a$10$QUOTjZgtTKnkj9pwIJZOoOCoKP8dWi8dbZ9.wto6FrQNdVFZx1HkO"
+	cases := []struct {
+		name        string
+		user, hash  string
+		wantEnabled bool
+		wantErr     bool
+	}{
+		{"both empty disables", "", "", false, false},
+		{"username only errors", "admin", "", false, true},
+		{"hash only errors", "", hash, false, true},
+		{"invalid hash errors", "admin", "not-a-bcrypt-hash", false, true},
+		{"valid enables", "admin", hash, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WIREKUBE_ADMIN_WEB_USERNAME", tc.user)
+			t.Setenv("WIREKUBE_ADMIN_WEB_PASSWORD_HASH", tc.hash)
+			auth, err := loadBasicAuth()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && tc.wantEnabled != (auth != nil) {
+				t.Fatalf("enabled = %v, want %v", auth != nil, tc.wantEnabled)
+			}
+		})
+	}
+}
+
 func TestIssuePeerRejectsMissingCSRF(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	s := newServer(c, time.Second, "wirekube-system")

--- a/config/examples/eks-hybrid/relay.yaml
+++ b/config/examples/eks-hybrid/relay.yaml
@@ -44,11 +44,13 @@ spec:
               protocol: UDP
           readinessProbe:
             tcpSocket:
+              host: 127.0.0.1
               port: 3478
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
+              host: 127.0.0.1
               port: 3478
             initialDelaySeconds: 5
             periodSeconds: 30

--- a/config/examples/eks-hybrid/relay.yaml
+++ b/config/examples/eks-hybrid/relay.yaml
@@ -43,15 +43,13 @@ spec:
               containerPort: 3478
               protocol: UDP
           readinessProbe:
-            tcpSocket:
-              host: 127.0.0.1
-              port: 3478
+            exec:
+              command: ["sh", "-c", "nc -z 127.0.0.1 3478"]
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
-              host: 127.0.0.1
-              port: 3478
+            exec:
+              command: ["sh", "-c", "nc -z 127.0.0.1 3478"]
             initialDelaySeconds: 5
             periodSeconds: 30
           resources:

--- a/config/relay/deployment.yaml
+++ b/config/relay/deployment.yaml
@@ -131,11 +131,13 @@ spec:
               protocol: UDP
           readinessProbe:
             tcpSocket:
+              host: 127.0.0.1
               port: 3478
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
+              host: 127.0.0.1
               port: 3478
             initialDelaySeconds: 5
             periodSeconds: 30

--- a/config/relay/deployment.yaml
+++ b/config/relay/deployment.yaml
@@ -150,7 +150,22 @@ spec:
           image: inerplat/wirekube:v0.0.0-dev.14
           command: ["wirekube-admin-web"]
           args:
+            # Binds to loopback only: the console is reachable via
+            # `kubectl port-forward` and is NOT exposed by either Service
+            # below. It ships with authentication DISABLED. Before exposing
+            # port 8080 (Ingress / NodePort / extra Service), you MUST enable
+            # HTTP Basic Auth by uncommenting the envFrom block below so the
+            # peer-management console (which can download private keys) is not
+            # left open.
             - --addr=127.0.0.1:8080
+          # envFrom:
+          #   # Create with:
+          #   #   HASH=$(htpasswd -bnBC 10 "" 's3cret' | tr -d ':\n' | sed 's/^\$2y/\$2a/')
+          #   #   kubectl -n wirekube-system create secret generic wirekube-admin-web-auth \
+          #   #     --from-literal=WIREKUBE_ADMIN_WEB_USERNAME=admin \
+          #   #     --from-literal=WIREKUBE_ADMIN_WEB_PASSWORD_HASH="$HASH"
+          #   - secretRef:
+          #       name: wirekube-admin-web-auth
           ports:
             - name: admin-web
               containerPort: 8080

--- a/config/relay/deployment.yaml
+++ b/config/relay/deployment.yaml
@@ -130,15 +130,13 @@ spec:
               containerPort: 3478
               protocol: UDP
           readinessProbe:
-            tcpSocket:
-              host: 127.0.0.1
-              port: 3478
+            exec:
+              command: ["sh", "-c", "nc -z 127.0.0.1 3478"]
             initialDelaySeconds: 2
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
-              host: 127.0.0.1
-              port: 3478
+            exec:
+              command: ["sh", "-c", "nc -z 127.0.0.1 3478"]
             initialDelaySeconds: 5
             periodSeconds: 30
           resources:

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
-
-// github.com/munnerz/gopapertrail has been deleted from GitHub but is referenced
-// as a transitive dependency. Using a local stub to satisfy the module graph.
-replace github.com/munnerz/gopapertrail => ./internal/gopapertrail-stub

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/crypto v0.26.0
 	golang.org/x/net v0.28.0
 	golang.org/x/sys v0.24.0
+	golang.org/x/time v0.6.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
@@ -68,7 +69,6 @@ require (
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
-	golang.org/x/time v0.6.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -813,6 +813,16 @@ func (a *Agent) sync(ctx context.Context) error {
 		allRoutes = connectedRoutes
 	}
 
+	// Reassert the WireKube ip rules every tick so they self-heal if a
+	// co-resident component (e.g. Cilium's ip-rule reconciliation) flushes
+	// them. Routes live in the WK table but are inert without these rules; a
+	// one-time flush would otherwise silently bypass the overlay, dropping
+	// traffic into the main table until the next agent restart. Non-fatal:
+	// log and continue so a transient netlink error doesn't abort the sync.
+	if err := a.wgMgr.EnsureRoutingRules(); err != nil {
+		a.log.Error(err, "reasserting routing rules")
+	}
+
 	// Sync kernel routes: AllowedIPs → wg interface
 	if err := a.wgMgr.SyncRoutes(allRoutes); err != nil {
 		return fmt.Errorf("syncing routes: %w", err)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1257,11 +1257,11 @@ func (a *Agent) updatePeerConnections(
 }
 
 // publishedTransportForPeer reports the user-visible transport mode for a
-// peer ("direct" vs "relay"). PathMonitor is the single source of truth:
-// Direct and Warm both publish as "direct" because Warm still prefers the
-// direct leg — the relay copy is belt-and-suspenders. Only PathModeRelay
-// (all direct receive evidence has expired) publishes as "relay". This
-// mirrors Tailscale's "trusted bestAddr" vs "DERP-only" distinction.
+// peer ("direct" vs "relay"). PathMonitor is the single source of truth: only
+// PathModeDirect (confirmed via fresh direct-receive evidence) publishes as
+// "direct"; PathModeWarm (direct unproven or being demoted), PathUnknown, and
+// PathModeRelay all publish as "relay", so the status never reports a probing
+// or unknown path as confirmed direct.
 // driveTransportMode asks PathMonitor for the current mode of every known
 // peer and commits it to the Bind via SetPeerPath. This runs at the end of
 // sync() and is authoritative — it overrides any intermediate SetPeerPath
@@ -1316,23 +1316,19 @@ func (a *Agent) publishedTransportForPeer(
 	peer *wirekubev1alpha1.WireKubePeer,
 	_ map[string]wireguard.PeerStats,
 ) string {
-	if peer == nil {
-		return "direct"
-	}
-	if a.pathMonitor == nil {
-		// Some unit tests construct Agent literals directly without going
-		// through NewAgent. Default to the safe answer rather than panic.
-		return "direct"
-	}
-	switch a.pathMonitor.ModeFor(peer.Name) {
-	case PathModeRelay:
+	// Only a confirmed direct path is reported as "direct". PathMonitor enters
+	// PathModeDirect only after fresh direct-receive evidence; PathModeWarm
+	// (direct unproven or being demoted), PathUnknown (not yet evaluated), and
+	// PathModeRelay all report "relay" so the status never overstates a direct
+	// path as confirmed. A nil peer or nil pathMonitor (test-only literal) has no
+	// evidence of direct connectivity, so it reports the conservative "relay".
+	if peer == nil || a.pathMonitor == nil {
 		return "relay"
-	default:
-		// PathUnknown, PathModeWarm, PathModeDirect all map to "direct":
-		// the caller treats "direct" as "we have or are trying a direct
-		// path", and "relay" as "we have given up on direct for now".
+	}
+	if a.pathMonitor.ModeFor(peer.Name) == PathModeDirect {
 		return "direct"
 	}
+	return "relay"
 }
 
 // initRelay sets up the relay client from the mesh relay configuration.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -102,6 +102,15 @@ type Agent struct {
 	// goroutine; they pace the background classification and prevent overlap.
 	lastNATClassify     time.Time
 	natClassifyInFlight bool
+	// birthdayCh hands a completed background birthday attack back to the sync
+	// goroutine. The attack blocks on UDP hole punching, but its RESULT — proxy
+	// adoption and the relay→direct upgrade — is applied only on the sync
+	// goroutine, the sole writer of iceStates/holePunchEndpoints/relayedPeers,
+	// so no lock is needed. Buffered generously (vs natClassCh's 1) because,
+	// unlike NAT classification, many symmetric↔symmetric pairs can have attacks
+	// completing in the same sync interval; a full buffer only blocks the
+	// background goroutine until the next drain (it never drops or leaks).
+	birthdayCh chan birthdayOutcome
 	// gwState tracks gateway configuration when this node serves as a VGW.
 	gwState *gatewayState
 	// wasInterfacePreserved is set during setup when an existing WireGuard
@@ -336,6 +345,9 @@ func (a *Agent) setup(ctx context.Context) error {
 	}
 	if a.natClassCh == nil {
 		a.natClassCh = make(chan *NATClassification, 1)
+	}
+	if a.birthdayCh == nil {
+		a.birthdayCh = make(chan birthdayOutcome, 16)
 	}
 	a.lastNATClassify = time.Now()
 
@@ -896,6 +908,11 @@ func (a *Agent) sync(ctx context.Context) error {
 	// Try upgrading relayed peers back to direct when conditions allow.
 	a.tryDirectUpgrade(peerList, statsByKey)
 
+	// Apply any completed background birthday attacks before driving transport,
+	// so a freshly hole-punched peer's direct path is reflected this cycle.
+	// Runs on the sync goroutine, the sole writer of the ICE/relay maps.
+	a.drainBirthdayResults()
+
 	// Apply any completed background NAT re-classification and arm the next one.
 	// Runs on the sync goroutine so it is the sole writer of detectedNATType etc.
 	a.maybeReclassifyNAT(ctx)
@@ -955,7 +972,13 @@ func (a *Agent) sync(ctx context.Context) error {
 	// Measure peer latency every 5th sync cycle (~2.5 min) to avoid overhead.
 	a.latencyCycle++
 	if a.latencyCycle%5 == 0 {
-		go a.measurePeerLatency(peerList)
+		// Snapshot the relayed-peer set on the sync goroutine; the latency
+		// goroutine must not read a.relayedPeers concurrently with sync.
+		relayed := make(map[string]bool, len(a.relayedPeers))
+		for name := range a.relayedPeers {
+			relayed[name] = true
+		}
+		go a.measurePeerLatency(peerList, relayed)
 	}
 
 	return nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -639,36 +639,40 @@ func (a *Agent) updateDiscoveryMethod(ctx context.Context, name, method string) 
 func (a *Agent) sync(ctx context.Context) error {
 	// Re-read relay mode from mesh CR so runtime changes are picked up.
 	pokeAfterSync := false
-	if mesh, err := a.getMesh(ctx); err == nil && mesh.Spec.Relay != nil {
-		oldMode := a.relayMode
-		newMode := mesh.Spec.Relay.Mode
-		if oldMode != newMode {
-			a.log.Info("relay mode changed", "oldMode", oldMode, "newMode", newMode)
-			a.relayMode = newMode
-			// When switching away from "always", reset ICE states so peers
-			// re-evaluate connectivity immediately instead of waiting for
-			// the relay retry interval. Without this, peers that were forced
-			// to relay by mode=always stay stuck because their ICE state
-			// (iceStateConnected) + relay endpoint causes probe failures.
-			if oldMode == relayModeAlways && newMode != relayModeAlways {
-				for name, state := range a.iceStates {
-					if state.State == iceStateConnected && a.relayedPeers[name] {
-						state.State = iceStateRelay
-						state.LastCheck = time.Time{} // zero → immediate retry
-						a.setICEState(name, state)
-						a.log.Info("reset ICE state due to mode change", "peer", name, "newMode", newMode)
+	var meshCIDR string
+	if mesh, err := a.getMesh(ctx); err == nil {
+		meshCIDR = mesh.Spec.MeshCIDR
+		if mesh.Spec.Relay != nil {
+			oldMode := a.relayMode
+			newMode := mesh.Spec.Relay.Mode
+			if oldMode != newMode {
+				a.log.Info("relay mode changed", "oldMode", oldMode, "newMode", newMode)
+				a.relayMode = newMode
+				// When switching away from "always", reset ICE states so peers
+				// re-evaluate connectivity immediately instead of waiting for
+				// the relay retry interval. Without this, peers that were forced
+				// to relay by mode=always stay stuck because their ICE state
+				// (iceStateConnected) + relay endpoint causes probe failures.
+				if oldMode == relayModeAlways && newMode != relayModeAlways {
+					for name, state := range a.iceStates {
+						if state.State == iceStateConnected && a.relayedPeers[name] {
+							state.State = iceStateRelay
+							state.LastCheck = time.Time{} // zero → immediate retry
+							a.setICEState(name, state)
+							a.log.Info("reset ICE state due to mode change", "peer", name, "newMode", newMode)
+						}
 					}
 				}
+				// Poke peers AFTER SyncPeers so that SetPeerPath(PathModeRelay)
+				// has been applied in the bind. Poking before would send the
+				// keepalive via the old path (Direct), causing the handshake
+				// to complete over direct UDP instead of relay.
+				if newMode == relayModeAlways && oldMode != relayModeAlways {
+					pokeAfterSync = true
+				}
+			} else {
+				a.relayMode = newMode
 			}
-			// Poke peers AFTER SyncPeers so that SetPeerPath(PathModeRelay)
-			// has been applied in the bind. Poking before would send the
-			// keepalive via the old path (Direct), causing the handshake
-			// to complete over direct UDP instead of relay.
-			if newMode == relayModeAlways && oldMode != relayModeAlways {
-				pokeAfterSync = true
-			}
-		} else {
-			a.relayMode = newMode
 		}
 	}
 
@@ -828,6 +832,7 @@ func (a *Agent) sync(ctx context.Context) error {
 			})
 			allRoutes = append(allRoutes, ep.Status.AssignedMeshIP)
 			routeOwners[ep.Status.AssignedMeshIP] = ep.Status.PublicKey
+			allowRoutesBeforeHandshake[ep.Status.PublicKey] = true
 		}
 	}
 
@@ -860,7 +865,7 @@ func (a *Agent) sync(ctx context.Context) error {
 	// handshake so bootstrap traffic can traverse the relay. API server CIDRs
 	// remain excluded regardless of transport mode.
 	if len(allRoutes) > 0 {
-		connectedRoutes := a.filterRoutesForConnectedPeers(allRoutes, routeOwners, allowRoutesBeforeHandshake)
+		connectedRoutes := a.filterRoutesForConnectedPeers(allRoutes, routeOwners, allowRoutesBeforeHandshake, meshCIDR)
 		if len(connectedRoutes) < len(allRoutes) {
 			a.log.V(2).Info("deferred routes for peers without handshake",
 				"connected", len(connectedRoutes), "total", len(allRoutes))
@@ -1167,10 +1172,13 @@ func (a *Agent) reflectNATEndpoints(ctx context.Context, peerList *wirekubev1alp
 
 // filterRoutesForConnectedPeers returns CIDRs that are safe to install in the
 // WireKube routing table. Direct-only peers still need a WireGuard handshake
-// before routes are installed. Relay-capable peers may need routes before the
-// first handshake because their first useful traffic can itself be what proves
-// the relay path. API server CIDRs are never routed through WireKube.
-func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, routeOwners map[string]string, allowBeforeHandshake map[string]bool) []string {
+// before routes are installed. Relay-capable peers may need the peer mesh /32
+// before the first handshake because their first useful traffic can itself be
+// what proves the relay path. Physical node/underlay AllowedIPs must still wait
+// for a handshake; installing them early can route the relay's own underlay path
+// into wire_kube and create a circular dependency. API server CIDRs are never
+// routed through WireKube.
+func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, routeOwners map[string]string, allowBeforeHandshake map[string]bool, meshCIDR string) []string {
 	stats, err := a.wgMgr.GetStats()
 	if err != nil {
 		a.log.Info("filterRoutes: GetStats failed, deferring all routes", "error", err)
@@ -1195,11 +1203,30 @@ func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, routeOwners ma
 			continue
 		}
 		key, ok := routeOwners[cidr]
-		if !ok || connected[key] || allowBeforeHandshake[key] {
+		if !ok || connected[key] || (allowBeforeHandshake[key] && isMeshHostRoute(cidr, meshCIDR)) {
 			result = append(result, cidr)
 		}
 	}
 	return result
+}
+
+func isMeshHostRoute(cidr, meshCIDR string) bool {
+	if meshCIDR == "" {
+		return false
+	}
+	ip, routeNet, err := net.ParseCIDR(cidr)
+	if err != nil || ip == nil || ip.To4() == nil {
+		return false
+	}
+	ones, bits := routeNet.Mask.Size()
+	if bits != 32 || ones != 32 {
+		return false
+	}
+	_, meshNet, err := net.ParseCIDR(meshCIDR)
+	if err != nil || meshNet == nil {
+		return false
+	}
+	return meshNet.Contains(ip)
 }
 
 func (a *Agent) canRouteBeforeHandshake(peerName string) bool {
@@ -1570,6 +1597,9 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 			return fmt.Errorf("external relay endpoint not configured")
 		}
 		endpoint = relay.External.Endpoint
+		if relay.External.ControlEndpoint != "" {
+			endpoint = relay.External.ControlEndpoint
+		}
 	case "managed":
 		port := int32(3478)
 		if relay.Managed != nil && relay.Managed.Port != 0 {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -646,6 +646,8 @@ func (a *Agent) sync(ctx context.Context) error {
 	myPeerName := a.nodeName
 	wgPeers := make([]wireguard.PeerConfig, 0, len(peerList.Items))
 	allRoutes := []string{}
+	routeOwners := map[string]string{}
+	allowRoutesBeforeHandshake := map[string]bool{}
 	ownAllowedIPsSet := false
 
 	// Build stats map for relay fallback decisions
@@ -710,6 +712,7 @@ func (a *Agent) sync(ctx context.Context) error {
 			}
 			filteredAllowedIPs = append(filteredAllowedIPs, cidr)
 			allRoutes = append(allRoutes, cidr)
+			routeOwners[cidr] = p.Spec.PublicKey
 		}
 		for _, cidr := range externalByIngress[p.Name] {
 			if a.shouldSkipGatewayRoute(ctx, cidr, myPeerName, ownIP) {
@@ -720,6 +723,7 @@ func (a *Agent) sync(ctx context.Context) error {
 			}
 			filteredAllowedIPs = append(filteredAllowedIPs, cidr)
 			allRoutes = append(allRoutes, cidr)
+			routeOwners[cidr] = p.Spec.PublicKey
 		}
 
 		// Symmetric peers must never be force-endpointed post-probe: the
@@ -740,6 +744,9 @@ func (a *Agent) sync(ctx context.Context) error {
 			KeepaliveSeconds: a.keepaliveForPeer(p),
 			ForceEndpoint:    forceEp,
 		})
+		if a.canRouteBeforeHandshake(p.Name) {
+			allowRoutesBeforeHandshake[p.Spec.PublicKey] = true
+		}
 	}
 
 	// Ingress-side external peer acceptance.
@@ -780,6 +787,7 @@ func (a *Agent) sync(ctx context.Context) error {
 				ForceEndpoint:    false,
 			})
 			allRoutes = append(allRoutes, ep.Status.AssignedMeshIP)
+			routeOwners[ep.Status.AssignedMeshIP] = ep.Status.PublicKey
 		}
 	}
 
@@ -807,12 +815,12 @@ func (a *Agent) sync(ctx context.Context) error {
 		}
 	}
 
-	// Filter routes: only install routes for peers that have completed a
-	// handshake. Without a handshake, the tunnel can't carry traffic — adding
-	// routes would redirect existing connectivity (e.g. to the API server)
-	// into a dead tunnel, breaking the agent's own control plane access.
+	// Filter routes: direct-only peers need a handshake before routes are
+	// installed, but relay-capable peers may need routes before the first
+	// handshake so bootstrap traffic can traverse the relay. API server CIDRs
+	// remain excluded regardless of transport mode.
 	if len(allRoutes) > 0 {
-		connectedRoutes := a.filterRoutesForConnectedPeers(allRoutes, wgPeers)
+		connectedRoutes := a.filterRoutesForConnectedPeers(allRoutes, routeOwners, allowRoutesBeforeHandshake)
 		if len(connectedRoutes) < len(allRoutes) {
 			a.log.V(2).Info("deferred routes for peers without handshake",
 				"connected", len(connectedRoutes), "total", len(allRoutes))
@@ -1090,10 +1098,12 @@ func (a *Agent) reflectNATEndpoints(ctx context.Context, peerList *wirekubev1alp
 	}
 }
 
-// filterRoutesForConnectedPeers returns only the CIDRs whose peer has completed
-// at least one WireGuard handshake. This prevents routing traffic into a tunnel
-// that can't yet carry it, which would break the agent's API server connectivity.
-func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, peers []wireguard.PeerConfig) []string {
+// filterRoutesForConnectedPeers returns CIDRs that are safe to install in the
+// WireKube routing table. Direct-only peers still need a WireGuard handshake
+// before routes are installed. Relay-capable peers may need routes before the
+// first handshake because their first useful traffic can itself be what proves
+// the relay path. API server CIDRs are never routed through WireKube.
+func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, routeOwners map[string]string, allowBeforeHandshake map[string]bool) []string {
 	stats, err := a.wgMgr.GetStats()
 	if err != nil {
 		a.log.Info("filterRoutes: GetStats failed, deferring all routes", "error", err)
@@ -1109,14 +1119,6 @@ func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, peers []wiregu
 	}
 	a.log.Info("filterRoutes", "totalStats", len(stats), "connectedPeers", len(connected), "totalRoutes", len(allRoutes))
 
-	// Build map: CIDR → peer public key
-	cidrToKey := make(map[string]string)
-	for _, p := range peers {
-		for _, cidr := range p.AllowedIPs {
-			cidrToKey[cidr] = p.PublicKeyB64
-		}
-	}
-
 	var result []string
 	for _, cidr := range allRoutes {
 		// Never route API server traffic through the WG tunnel.
@@ -1125,12 +1127,30 @@ func (a *Agent) filterRoutesForConnectedPeers(allRoutes []string, peers []wiregu
 		if a.isAPIServerCIDR(cidr) {
 			continue
 		}
-		key, ok := cidrToKey[cidr]
-		if !ok || connected[key] {
+		key, ok := routeOwners[cidr]
+		if !ok || connected[key] || allowBeforeHandshake[key] {
 			result = append(result, cidr)
 		}
 	}
 	return result
+}
+
+func (a *Agent) canRouteBeforeHandshake(peerName string) bool {
+	if peerName == "" || a.relayMode == relayModeNever || !a.relayTransportUsable() {
+		return false
+	}
+	if a.relayedPeers[peerName] {
+		return true
+	}
+	if a.pathMonitor == nil {
+		return false
+	}
+	switch a.pathMonitor.ModeFor(peerName) {
+	case PathModeRelay, PathModeWarm:
+		return true
+	default:
+		return false
+	}
 }
 
 // updateOwnStatus reads WireGuard stats and updates this node's WireKubePeer status.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -868,12 +868,14 @@ func (a *Agent) sync(ctx context.Context) error {
 		allRoutes = connectedRoutes
 	}
 
-	// Reassert the WireKube ip rules every tick so they self-heal if a
+	// Reassert the WireKube-managed ip rules every tick so they self-heal if a
 	// co-resident component (e.g. Cilium's ip-rule reconciliation) flushes
-	// them. Routes live in the WK table but are inert without these rules; a
-	// one-time flush would otherwise silently bypass the overlay, dropping
-	// traffic into the main table until the next agent restart. Non-fatal:
-	// log and continue so a transient netlink error doesn't abort the sync.
+	// them. Routes live in the WK table but are inert without these rules, and
+	// the API server bypass rule must survive the same flush events to keep the
+	// agent from routing its own control-plane traffic through the overlay.
+	// Non-fatal: log and continue so a transient netlink error doesn't abort
+	// the sync.
+	a.ensureAPIServerRoute()
 	if err := a.wgMgr.EnsureRoutingRules(); err != nil {
 		a.log.Error(err, "reasserting routing rules")
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1441,6 +1441,10 @@ func (a *Agent) applyNATClassification(ctx context.Context, c *NATClassification
 		a.portPrediction = nil
 	}
 
+	// Our NAT type changed — let every peer re-probe promptly instead of waiting
+	// out an unstable-NAT backoff, since the new type may make a stuck pair viable.
+	a.clearDirectReprobeBackoff()
+
 	if err := a.publishNATClassification(ctx); err != nil {
 		a.log.Error(err, "publishing re-classified NAT status")
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1419,6 +1419,18 @@ func (a *Agent) applyNATClassification(ctx context.Context, c *NATClassification
 	}
 
 	newType := string(c.NATType)
+
+	// The periodic classifier is STUN-only and cannot distinguish port-restricted
+	// cone from plain cone — that distinction needs the relay dual-probe run once
+	// at setup (DetectPortRestriction). A "cone" result must therefore NOT
+	// downgrade an existing port-restricted-cone refinement: they are the same NAT
+	// family, and downgrading would wrongly un-pin a port-restricted↔symmetric pair
+	// from relay (it would then probe a structurally impossible direct path) and
+	// drop the CGNAT keepalive override. Keep the more-specific refined type.
+	if oldType == string(nat.NATPortRestrictedCone) && c.NATType == nat.NATCone {
+		return
+	}
+
 	if newType == oldType {
 		// Same type: refresh port prediction for symmetric peers (mapped ports
 		// drift over time), otherwise nothing to do.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -87,6 +87,21 @@ type Agent struct {
 	ownPublicKeyB64 string
 	// portPrediction stores our NAT port prediction data from STUN.
 	portPrediction *nat.PortPrediction
+	// stunServers is the STUN server list from the mesh, cached at setup for
+	// periodic NAT re-classification.
+	stunServers []string
+	// reclassifyEvery is the minimum interval between periodic NAT
+	// re-classifications. Defaulted in setup if unset.
+	reclassifyEvery time.Duration
+	// natClassCh hands a completed background NAT classification back to the
+	// sync goroutine. STUN runs off-loop (it can block up to 10s), but the
+	// RESULT is applied only on the sync goroutine — the sole writer of
+	// detectedNATType/isSymmetricNAT/portPrediction — so no lock is needed.
+	natClassCh chan *NATClassification
+	// lastNATClassify / natClassifyInFlight are touched only on the sync
+	// goroutine; they pace the background classification and prevent overlap.
+	lastNATClassify     time.Time
+	natClassifyInFlight bool
 	// gwState tracks gateway configuration when this node serves as a VGW.
 	gwState *gatewayState
 	// wasInterfacePreserved is set during setup when an existing WireGuard
@@ -310,6 +325,19 @@ func (a *Agent) setup(ctx context.Context) error {
 			a.annotateOwnPod(ctx, ip)
 		}
 	}
+
+	// Cache STUN servers and arm periodic NAT re-classification so a transient
+	// STUN failure at startup self-heals without a pod restart. lastNATClassify
+	// is seeded to now because we classify once right here; the first periodic
+	// re-classification happens one reclassifyEvery later.
+	a.stunServers = mesh.Spec.STUNServers
+	if a.reclassifyEvery == 0 {
+		a.reclassifyEvery = 45 * time.Second
+	}
+	if a.natClassCh == nil {
+		a.natClassCh = make(chan *NATClassification, 1)
+	}
+	a.lastNATClassify = time.Now()
 
 	epResult, err := DiscoverEndpoint(ctx, node, int(mesh.Spec.ListenPort), mesh.Spec.STUNServers)
 	if err != nil {
@@ -858,6 +886,10 @@ func (a *Agent) sync(ctx context.Context) error {
 	// Try upgrading relayed peers back to direct when conditions allow.
 	a.tryDirectUpgrade(peerList, statsByKey)
 
+	// Apply any completed background NAT re-classification and arm the next one.
+	// Runs on the sync goroutine so it is the sole writer of detectedNATType etc.
+	a.maybeReclassifyNAT(ctx)
+
 	// Drive the PathMonitor FSM for every remote peer and commit the
 	// resulting transport mode to the Bind. This is the single authoritative
 	// SetPeerPath call per sync cycle — legacy SetPeerPath calls earlier in
@@ -1329,6 +1361,104 @@ func (a *Agent) publishedTransportForPeer(
 		return "direct"
 	}
 	return "relay"
+}
+
+// maybeReclassifyNAT applies a completed background NAT classification and arms
+// the next one. It runs on the sync goroutine only.
+//
+// Concurrency: the blocking STUN probe runs in a background goroutine (it can
+// take up to 10s and must not stall the sync loop), but that goroutine ONLY
+// produces a *NATClassification and hands it back on natClassCh. Every mutation
+// of detectedNATType / isSymmetricNAT / portPrediction happens here, on the sync
+// goroutine — the agent has no mutex, and this keeps it that way.
+func (a *Agent) maybeReclassifyNAT(ctx context.Context) {
+	// Drain a completed classification, if any, and apply it.
+	select {
+	case c := <-a.natClassCh:
+		if c != nil {
+			a.applyNATClassification(ctx, c)
+		}
+	default:
+	}
+
+	if a.natClassifyInFlight {
+		return
+	}
+	if !a.lastNATClassify.IsZero() && time.Since(a.lastNATClassify) < a.reclassifyEvery {
+		return
+	}
+	a.lastNATClassify = time.Now()
+	a.natClassifyInFlight = true
+	servers := a.stunServers
+	ch := a.natClassCh
+	go func() {
+		c := ClassifyNAT(ctx, servers)
+		select {
+		case ch <- c:
+		case <-ctx.Done():
+		}
+	}()
+}
+
+// applyNATClassification folds a fresh classification into agent state and the
+// published CRD status. Called only from maybeReclassifyNAT (sync goroutine).
+//
+// A NATUnknown result (partial or total STUN failure) is treated as transient:
+// it is logged but does NOT overwrite a previously-known type, so a brief STUN
+// outage self-heals on a later cycle instead of wiping classification and
+// flapping. Only a known type updates state, and only when it actually changed.
+func (a *Agent) applyNATClassification(ctx context.Context, c *NATClassification) {
+	a.natClassifyInFlight = false
+	oldType := a.detectedNATType
+
+	if c.NATType == nat.NATUnknown {
+		a.log.Info("NAT re-classification inconclusive, keeping previous type",
+			"previousNATType", oldType, "serversResponded", c.ServersResponded,
+			"serversTotal", c.ServersTotal, "reason", c.Error)
+		return
+	}
+
+	newType := string(c.NATType)
+	if newType == oldType {
+		// Same type: refresh port prediction for symmetric peers (mapped ports
+		// drift over time), otherwise nothing to do.
+		if c.NATType == nat.NATSymmetric && c.PortPrediction != nil {
+			a.portPrediction = c.PortPrediction
+		}
+		return
+	}
+
+	a.log.Info("NAT re-classification changed type",
+		"previousNATType", oldType, "natType", newType,
+		"serversResponded", c.ServersResponded, "serversTotal", c.ServersTotal)
+
+	a.detectedNATType = newType
+	a.isSymmetricNAT = c.NATType == nat.NATSymmetric
+	if c.NATType == nat.NATSymmetric {
+		a.portPrediction = c.PortPrediction
+	} else {
+		// Non-symmetric: drop any stale symmetric port prediction.
+		a.portPrediction = nil
+	}
+
+	if err := a.publishNATClassification(ctx); err != nil {
+		a.log.Error(err, "publishing re-classified NAT status")
+	}
+}
+
+// publishNATClassification writes the current detectedNATType / portPrediction
+// to this node's WireKubePeer status. Clearing portPrediction (symmetric → cone)
+// relies on MergeFrom emitting an explicit null for the now-nil pointer field;
+// TestPublishNATClassificationClears asserts the field is actually removed.
+func (a *Agent) publishNATClassification(ctx context.Context) error {
+	peer := &wirekubev1alpha1.WireKubePeer{}
+	if err := a.client.Get(ctx, client.ObjectKey{Name: a.nodeName}, peer); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(peer.DeepCopy())
+	peer.Status.NATType = a.detectedNATType
+	peer.Status.PortPrediction = crdPortPrediction(a.portPrediction)
+	return a.client.Status().Patch(ctx, peer, patch)
 }
 
 // initRelay sets up the relay client from the mesh relay configuration.

--- a/pkg/agent/birthday_test.go
+++ b/pkg/agent/birthday_test.go
@@ -1,0 +1,200 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+)
+
+// newTestProxy builds a holePunchProxy backed by real loopback UDP sockets but
+// without starting Run(), so ListenAddr() and Close() work in tests.
+func newTestProxy(t *testing.T) *holePunchProxy {
+	t.Helper()
+	lc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen local: %v", err)
+	}
+	hc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		lc.Close()
+		t.Fatalf("listen hole: %v", err)
+	}
+	return &holePunchProxy{localConn: lc, holeConn: hc, stopCh: make(chan struct{})}
+}
+
+// TestApplyBirthdayOutcomeFailure verifies a failed attack (nil proxy) marks the
+// peer's ICE state failed without needing a WireGuard manager.
+func TestApplyBirthdayOutcomeFailure(t *testing.T) {
+	a := &Agent{log: logr.Discard()}
+	peer := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "peer-a"}}
+
+	a.applyBirthdayOutcome(birthdayOutcome{peer: peer, proxy: nil})
+
+	state := a.getICEState("peer-a")
+	if state.State != iceStateFailed {
+		t.Fatalf("state = %v, want %v", state.State, iceStateFailed)
+	}
+	if state.LastCheck.IsZero() {
+		t.Fatal("LastCheck not set on failure")
+	}
+}
+
+// TestBirthdayResultsHandoffRace exercises the birthdayCh handoff: many
+// background goroutines report results concurrently while a single sync-side
+// goroutine drains them and mutates the iceStates map. Under `go test -race`
+// this asserts the fix — background attacks no longer touch shared maps; all
+// mutation happens on the draining (sync) goroutine.
+func TestBirthdayResultsHandoffRace(t *testing.T) {
+	a := &Agent{log: logr.Discard(), birthdayCh: make(chan birthdayOutcome, 16)}
+	ctx := context.Background()
+
+	const senders = 8
+	const perSender = 50
+	target := senders * perSender
+
+	var wg sync.WaitGroup
+	wg.Add(senders)
+	for s := 0; s < senders; s++ {
+		go func(s int) {
+			defer wg.Done()
+			for i := 0; i < perSender; i++ {
+				peer := &wirekubev1alpha1.WireKubePeer{
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("peer-%d-%d", s, i)},
+				}
+				a.reportBirthday(ctx, peer, nil) // failure path: no wgMgr needed
+			}
+		}(s)
+	}
+
+	stop := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			a.drainBirthdayResults()
+			select {
+			case <-stop:
+				a.drainBirthdayResults() // final pass
+				return
+			default:
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	wg.Wait()     // all results sent (drainer keeps the buffer clear)
+	close(stop)   // let the drainer finish and exit
+	<-drained
+
+	if got := len(a.iceStates); got != target {
+		t.Fatalf("iceStates = %d, want %d", got, target)
+	}
+}
+
+// TestBirthdayResultsSuccessRace exercises the success path: applyBirthdayOutcome
+// folds a non-nil proxy via upgradeToDirect, which mutates peerFirstSeen,
+// holePunchEndpoints, relayGracePeers and relayedPeers. Concurrent senders push
+// results while the single sync-side goroutine drains; under `go test -race`
+// this proves those maps keep their single-writer invariant.
+func TestBirthdayResultsSuccessRace(t *testing.T) {
+	a := &Agent{
+		log:                logr.Discard(),
+		wgMgr:              &fakeWGEngine{},
+		birthdayCh:         make(chan birthdayOutcome, 16),
+		iceStates:          map[string]*peerICEState{},
+		peerFirstSeen:      map[string]time.Time{},
+		holePunchEndpoints: map[string]string{},
+		directEndpoints:    map[string]string{},
+		relayedPeers:       map[string]bool{},
+		relayGracePeers:    map[string]bool{},
+	}
+	ctx := context.Background()
+
+	const target = 48
+	proxies := make([]*holePunchProxy, target)
+	peers := make([]*wirekubev1alpha1.WireKubePeer, target)
+	for i := 0; i < target; i++ {
+		proxies[i] = newTestProxy(t)
+		name := fmt.Sprintf("peer-%d", i)
+		peers[i] = &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		// Seed as relayed so upgradeToDirect exercises the relayGracePeers path.
+		a.relayedPeers[name] = true
+	}
+	t.Cleanup(func() {
+		for _, p := range proxies {
+			p.Close()
+		}
+	})
+
+	const senders = 6
+	var wg sync.WaitGroup
+	wg.Add(senders)
+	for s := 0; s < senders; s++ {
+		go func(s int) {
+			defer wg.Done()
+			for i := s; i < target; i += senders {
+				a.reportBirthday(ctx, peers[i], proxies[i])
+			}
+		}(s)
+	}
+
+	stop := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			a.drainBirthdayResults()
+			select {
+			case <-stop:
+				a.drainBirthdayResults()
+				return
+			default:
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-drained
+
+	if got := len(a.holePunchEndpoints); got != target {
+		t.Fatalf("holePunchEndpoints = %d, want %d", got, target)
+	}
+	if len(a.relayedPeers) != 0 {
+		t.Fatalf("relayedPeers = %d, want 0 (all upgraded to direct)", len(a.relayedPeers))
+	}
+	if got := len(a.relayGracePeers); got != target {
+		t.Fatalf("relayGracePeers = %d, want %d", got, target)
+	}
+}
+
+// TestReportBirthdayClosesProxyOnCancel verifies the shutdown leak guard: when
+// the context is done before the result is drained, reportBirthday closes the
+// proxy instead of leaking it.
+func TestReportBirthdayClosesProxyOnCancel(t *testing.T) {
+	a := &Agent{log: logr.Discard(), birthdayCh: make(chan birthdayOutcome)} // unbuffered: send blocks
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	proxy := newTestProxy(t)
+	a.reportBirthday(ctx, &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "p"}}, proxy)
+
+	// Close is idempotent (sync.Once); if reportBirthday already closed it, the
+	// stopCh is closed and a second Close is a no-op. Detect closure via stopCh.
+	select {
+	case <-proxy.stopCh:
+		// closed as expected
+	default:
+		t.Fatal("proxy was not closed on ctx cancellation")
+	}
+}

--- a/pkg/agent/birthday_test.go
+++ b/pkg/agent/birthday_test.go
@@ -91,8 +91,8 @@ func TestBirthdayResultsHandoffRace(t *testing.T) {
 		}
 	}()
 
-	wg.Wait()     // all results sent (drainer keeps the buffer clear)
-	close(stop)   // let the drainer finish and exit
+	wg.Wait()   // all results sent (drainer keeps the buffer clear)
+	close(stop) // let the drainer finish and exit
 	<-drained
 
 	if got := len(a.iceStates); got != target {

--- a/pkg/agent/endpoint.go
+++ b/pkg/agent/endpoint.go
@@ -250,7 +250,6 @@ func buildSTUNResult(sr *nat.STUNResult, listenPort int, useListenPort bool) *En
 type NATClassification struct {
 	NATType          nat.NATType
 	PortPrediction   *nat.PortPrediction
-	Source           DiscoveryMethod
 	ServersResponded int
 	ServersTotal     int
 	// Error summarizes why NATType is NATUnknown (partial or total STUN
@@ -279,12 +278,11 @@ func classificationFromSTUN(sr *nat.STUNResult, err error) *NATClassification {
 		if err != nil {
 			msg = err.Error()
 		}
-		return &NATClassification{NATType: nat.NATUnknown, Source: MethodSTUN, Error: msg}
+		return &NATClassification{NATType: nat.NATUnknown, Error: msg}
 	}
 	c := &NATClassification{
 		NATType:          sr.NATType,
 		PortPrediction:   sr.PortPrediction,
-		Source:           MethodSTUN,
 		ServersResponded: sr.ServersResponded,
 		ServersTotal:     sr.ServersTotal,
 	}

--- a/pkg/agent/endpoint.go
+++ b/pkg/agent/endpoint.go
@@ -241,3 +241,56 @@ func buildSTUNResult(sr *nat.STUNResult, listenPort int, useListenPort bool) *En
 		PortEstimated:  portEstimated,
 	}
 }
+
+// NATClassification is the result of NAT-type detection. It is kept separate
+// from EndpointResult so the agent can re-classify NAT periodically without
+// disturbing the chosen endpoint — endpoint selection and NAT classification
+// have independent lifecycles (a UPnP endpoint can stay published while NAT
+// classification recovers via STUN, and vice versa).
+type NATClassification struct {
+	NATType          nat.NATType
+	PortPrediction   *nat.PortPrediction
+	Source           DiscoveryMethod
+	ServersResponded int
+	ServersTotal     int
+	// Error summarizes why NATType is NATUnknown (partial or total STUN
+	// failure). Empty when the type was determined.
+	Error string
+}
+
+// ClassifyNAT determines NAT type and port prediction by running STUN on an
+// ephemeral port. It never binds the WireGuard listen socket, so it is safe to
+// call repeatedly while the interface is up — the agent uses it to re-classify
+// periodically and self-heal after a transient STUN failure. It performs no
+// endpoint selection.
+func ClassifyNAT(ctx context.Context, stunServers []string) *NATClassification {
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	sr, err := nat.DiscoverPublicEndpointWithNATType(cctx, 0, stunServers)
+	return classificationFromSTUN(sr, err)
+}
+
+// classificationFromSTUN maps a raw STUN outcome to a NATClassification. It is
+// split out from ClassifyNAT so the mapping (especially the partial-success
+// "1 of N responded → unknown" case) is unit-testable without a STUN server.
+func classificationFromSTUN(sr *nat.STUNResult, err error) *NATClassification {
+	if err != nil || sr == nil {
+		msg := "all STUN servers failed"
+		if err != nil {
+			msg = err.Error()
+		}
+		return &NATClassification{NATType: nat.NATUnknown, Source: MethodSTUN, Error: msg}
+	}
+	c := &NATClassification{
+		NATType:          sr.NATType,
+		PortPrediction:   sr.PortPrediction,
+		Source:           MethodSTUN,
+		ServersResponded: sr.ServersResponded,
+		ServersTotal:     sr.ServersTotal,
+	}
+	if sr.NATType == nat.NATUnknown {
+		c.Error = fmt.Sprintf("only %d of %d STUN servers responded — cannot detect NAT type",
+			sr.ServersResponded, sr.ServersTotal)
+	}
+	return c
+}

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -962,6 +962,9 @@ func (a *Agent) evaluateICECheck(ctx context.Context, peer *wirekubev1alpha1.Wir
 			(!isStableDirectNAT(a.detectedNATType) || !isStableDirectNAT(peer.Status.NATType)) {
 			backoff := a.unstableProbeBackoff()
 			state.NextProbeAfter = time.Now().Add(backoff)
+			if a.pathMonitor != nil {
+				a.pathMonitor.BackoffDirectProbeUntil(peer.Name, peer.Spec.PublicKey, state.NextProbeAfter)
+			}
 			a.log.Info("unstable NAT pair failing repeatedly, backing off direct probes",
 				"peer", peer.Name, "failures", state.ProbeFailCount, "backoff", backoff)
 		}
@@ -1212,12 +1215,15 @@ func (a *Agent) unstableProbeBackoff() time.Duration {
 // be premature (it would race the imminent relay→direct upgrade in intent, not
 // in memory — all ICE-state writes are on the sync goroutine).
 func (a *Agent) clearDirectReprobeBackoff() {
-	for _, s := range a.iceStates {
+	for name, s := range a.iceStates {
 		if s.State == iceStateBirthday {
 			continue
 		}
 		s.NextProbeAfter = time.Time{}
 		s.ProbeFailCount = 0
+		if a.pathMonitor != nil {
+			a.pathMonitor.ClearProbeBackoff(name)
+		}
 	}
 }
 

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -1158,15 +1158,23 @@ func (a *Agent) unstableProbeBackoff() time.Duration {
 	return d
 }
 
-// clearDirectReprobeBackoff resets every peer's NextProbeAfter so they re-probe
-// promptly. Called when local NAT re-classification changes, since the new type
-// may make previously-stuck pairs viable. Note this also clears the short
+// clearDirectReprobeBackoff lets every peer re-probe promptly after a local NAT
+// re-classification: it clears the probe backoff (NextProbeAfter) AND resets
+// ProbeFailCount so the next iceStateFailed/Relay cycle uses the fast retry
+// interval instead of the full relayRetry. Clearing also drops the short
 // directFailoverProbeCooldown set by deferDirectReprobe — intended, because a
-// NAT-type change invalidates the prior failover assumption. Runs on the sync
-// goroutine (the only writer of iceStates), so no lock is needed.
+// NAT-type change invalidates the prior failover assumption.
+//
+// Peers mid birthday-attack are skipped: their *peerICEState is concurrently
+// mutated by the background runBirthdayAttack goroutine (a pre-existing aspect of
+// the ICE state machine), so the sync goroutine must not also write it here.
 func (a *Agent) clearDirectReprobeBackoff() {
 	for _, s := range a.iceStates {
+		if s.State == iceStateBirthday {
+			continue
+		}
 		s.NextProbeAfter = time.Time{}
+		s.ProbeFailCount = 0
 	}
 }
 

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -952,6 +952,18 @@ func (a *Agent) evaluateICECheck(ctx context.Context, peer *wirekubev1alpha1.Wir
 		a.log.Info("active probe failed, reverting to relay", "peer", peer.Name, "failures", state.ProbeFailCount)
 		state.State = iceStateFailed
 		state.LastCheck = time.Now()
+		// Unstable/unknown-NAT pairs that have never received direct traffic and
+		// keep failing are unlikely to go direct soon — back off probing longer to
+		// cut churn (relay stays fully active). Recovery still happens via NAT
+		// re-classification (clearDirectReprobeBackoff) or direct inbound.
+		if state.ProbeFailCount >= unstableProbeFailThreshold &&
+			a.wgMgr.LastDirectReceive(peer.Spec.PublicKey) <= 0 && // 0 = never, <0 = engine has no signal
+			(!isStableDirectNAT(a.detectedNATType) || !isStableDirectNAT(peer.Status.NATType)) {
+			backoff := a.unstableProbeBackoff()
+			state.NextProbeAfter = time.Now().Add(backoff)
+			a.log.Info("unstable NAT pair failing repeatedly, backing off direct probes",
+				"peer", peer.Name, "failures", state.ProbeFailCount, "backoff", backoff)
+		}
 		a.setICEState(peer.Name, state)
 		return
 	}
@@ -1123,6 +1135,38 @@ func (a *Agent) deferDirectReprobe(peerName string, delay time.Duration) {
 	if next.After(state.NextProbeAfter) {
 		state.NextProbeAfter = next
 		a.setICEState(peerName, state)
+	}
+}
+
+// unstableProbeFailThreshold is how many consecutive failed direct probes an
+// unstable/unknown-NAT peer may accumulate before the agent backs off probing
+// for unstableProbeBackoff instead of re-probing every relayRetry. This cuts
+// churn for pairs that cannot currently go direct (e.g. our NAT is still
+// unclassified) while leaving the relay path fully functional. Recovery still
+// happens promptly: NAT re-classification clears the backoff
+// (clearDirectReprobeBackoff), as does the relay-state direct-inbound fast-track.
+const unstableProbeFailThreshold = 3
+
+// unstableProbeBackoff is the relay hold applied after repeated direct-probe
+// failures on an unstable/unknown-NAT pair. Bounded well above relayRetry so the
+// agent is not re-probing a structurally-stuck pair every cycle.
+func (a *Agent) unstableProbeBackoff() time.Duration {
+	d := a.relayRetry * 5
+	if d < 10*time.Minute {
+		d = 10 * time.Minute
+	}
+	return d
+}
+
+// clearDirectReprobeBackoff resets every peer's NextProbeAfter so they re-probe
+// promptly. Called when local NAT re-classification changes, since the new type
+// may make previously-stuck pairs viable. Note this also clears the short
+// directFailoverProbeCooldown set by deferDirectReprobe — intended, because a
+// NAT-type change invalidates the prior failover assumption. Runs on the sync
+// goroutine (the only writer of iceStates), so no lock is needed.
+func (a *Agent) clearDirectReprobeBackoff() {
+	for _, s := range a.iceStates {
+		s.NextProbeAfter = time.Time{}
 	}
 }
 

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -556,44 +556,9 @@ func (a *Agent) startICECheck(ctx context.Context, peer *wirekubev1alpha1.WireKu
 		return
 	}
 
+	sym := string(nat.NATSymmetric)
 	switch {
-	case myNAT != "symmetric" && peerNAT != "symmetric":
-		// Cone ↔ Cone: both endpoints are stable. Active probe is safe and fast
-		// because the peer can reach us at our stable STUN endpoint simultaneously.
-		a.log.V(1).Info("cone↔cone — active probe", "peer", peer.Name, "endpoint", peer.Spec.Endpoint)
-		a.probeDirectEndpoint(peer)
-
-	case myNAT != "symmetric" && peerNAT == "symmetric":
-		// Cone ↔ Symmetric: simultaneous active probe from both sides.
-		//
-		// Passive-only approach fails for two reasons:
-		//   1. The symmetric peer's relay keepalives (sent while we stay on relay)
-		//      arrive at our relay proxy and are forwarded to our WG with a
-		//      localhost source. WG roams back to the localhost proxy address,
-		//      so ActualEndpoint stays "127.0.0.1:PORT" and probeOK is always
-		//      false even when the direct handshake succeeds.
-		//   2. Many home routers use address-restricted cone NAT: inbound packets
-		//      from a source IP are only forwarded if we have previously sent
-		//      something to that IP. Passive mode never sends to the symmetric
-		//      peer's IP, so the NAT filter blocks their probe.
-		//
-		// By probing actively on both sides simultaneously:
-		//   - We send to the symmetric peer's CRD endpoint (packet is dropped by
-		//     their symmetric NAT, but it opens our address-restricted filter for
-		//     their IP and stops our WG from sending keepalives via relay).
-		//   - The symmetric peer probes our stable STUN endpoint; with our NAT
-		//     filter now open their probe gets through and the handshake completes.
-		// Relay stays fully active while probing so failover remains seamless even
-		// when the direct path is impossible.
-		a.log.V(1).Info("cone↔symmetric — simultaneous probe (opens NAT filter)", "peer", peer.Name, "endpoint", peer.Spec.Endpoint)
-		a.probeDirectEndpoint(peer)
-
-	case myNAT == "symmetric" && peerNAT != "symmetric":
-		// Symmetric ↔ Cone: we should probe the peer's stable endpoint.
-		a.log.V(1).Info("symmetric↔cone — active probe", "peer", peer.Name, "endpoint", peer.Spec.Endpoint)
-		a.probeDirectEndpoint(peer)
-
-	case myNAT == "symmetric" && peerNAT == "symmetric":
+	case myNAT == sym && peerNAT == sym:
 		if ok, reason := a.canStartBirthdayAttack(peer, state); ok {
 			a.log.Info("symmetric↔symmetric — initiating birthday attack", "peer", peer.Name)
 			state.State = iceStateBirthday
@@ -603,6 +568,39 @@ func (a *Agent) startICECheck(ctx context.Context, peer *wirekubev1alpha1.WireKu
 			a.log.Info("symmetric↔symmetric — staying on relay", "peer", peer.Name, "reason", reason)
 			state.State = iceStateFailed
 		}
+
+	case myNAT == sym || peerNAT == sym:
+		// One side symmetric, the other non-symmetric: simultaneous active probe
+		// from both sides. Probing actively (rather than passively) matters:
+		//   1. The symmetric peer's relay keepalives arrive at our relay proxy and
+		//      are forwarded to WG with a localhost source, so WG roams back to the
+		//      127.0.0.1 proxy and a successful direct handshake is undetectable.
+		//   2. Address-restricted cone NAT only forwards inbound packets from an IP
+		//      we have already sent to; passive mode never sends to the peer's IP.
+		// By probing actively on both sides we send to the symmetric peer's CRD
+		// endpoint (opening our NAT filter for their IP and stopping the relay
+		// keepalive loop) while they probe our stable endpoint, so the handshake
+		// can complete. Relay stays fully active so failover remains seamless when
+		// the direct path is impossible.
+		a.log.V(1).Info("symmetric↔non-symmetric — simultaneous probe (opens NAT filter)", "peer", peer.Name, "endpoint", peer.Spec.Endpoint)
+		a.probeDirectEndpoint(peer)
+
+	case isStableDirectNAT(myNAT) && isStableDirectNAT(peerNAT):
+		// Both ends confirmed stable (open/cone): the peer can reach us at our
+		// stable endpoint simultaneously, so an active probe is safe and fast.
+		a.log.V(1).Info("stable↔stable — active probe", "peer", peer.Name, "endpoint", peer.Spec.Endpoint)
+		a.probeDirectEndpoint(peer)
+
+	default:
+		// At least one side is unclassified ("" / unknown), and neither is
+		// symmetric. We must NOT treat unknown as a stable cone — doing so is what
+		// let unclassified peers be probed as if confirmed-direct. We still attempt
+		// a probe (classification alone must never refuse a path that might work),
+		// but log it as speculative. PathMonitor remains the authority on whether
+		// the resulting path is actually direct; repeated failures are handled by
+		// the relay backoff in runICENegotiation.
+		a.log.V(1).Info("unclassified NAT — speculative probe", "peer", peer.Name, "myNAT", myNAT, "peerNAT", peerNAT, "endpoint", peer.Spec.Endpoint)
+		a.probeDirectEndpoint(peer)
 	}
 
 	a.setICEState(peer.Name, state)
@@ -624,6 +622,16 @@ func isPortRestrictedSymmetricPair(myNAT, peerNAT string) bool {
 func isSymmetricSymmetricPair(myNAT, peerNAT string) bool {
 	sym := string(nat.NATSymmetric)
 	return myNAT == sym && peerNAT == sym
+}
+
+// isStableDirectNAT reports whether a NAT type is known-stable enough that an
+// immediate cone-style active probe is appropriate. Only "open" and "cone" map
+// a fixed external port that a peer can reach simultaneously. Crucially, the
+// unknown/unclassified type ("") is NOT stable: treating it as such is what let
+// unclassified peers be probed as if they were confirmed-direct. Symmetric and
+// port-restricted-cone are likewise not stable for cone-style probing.
+func isStableDirectNAT(natType string) bool {
+	return natType == string(nat.NATOpen) || natType == string(nat.NATCone)
 }
 
 // shouldPermanentRelay reports whether this peer pair has been determined

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -339,19 +339,28 @@ func (a *Agent) publishICEState(ctx context.Context, peerName string, candidates
 	peer.Status.ICEState = iceState
 
 	if portPred != nil {
-		pp := &wirekubev1alpha1.PortPrediction{
-			BasePort:    int32(portPred.BasePort),
-			Increment:   int32(portPred.Increment),
-			Jitter:      int32(portPred.Jitter),
-			SamplePorts: make([]int32, len(portPred.SamplePorts)),
-		}
-		for i, p := range portPred.SamplePorts {
-			pp.SamplePorts[i] = int32(p)
-		}
-		peer.Status.PortPrediction = pp
+		peer.Status.PortPrediction = crdPortPrediction(portPred)
 	}
 
 	return a.client.Status().Patch(ctx, peer, patch)
+}
+
+// crdPortPrediction converts an internal nat.PortPrediction to the CRD status
+// type, returning nil for nil input so callers can clear the field.
+func crdPortPrediction(pp *nat.PortPrediction) *wirekubev1alpha1.PortPrediction {
+	if pp == nil {
+		return nil
+	}
+	out := &wirekubev1alpha1.PortPrediction{
+		BasePort:    int32(pp.BasePort),
+		Increment:   int32(pp.Increment),
+		Jitter:      int32(pp.Jitter),
+		SamplePorts: make([]int32, len(pp.SamplePorts)),
+	}
+	for i, p := range pp.SamplePorts {
+		out.SamplePorts[i] = int32(p)
+	}
+	return out
 }
 
 // runICENegotiation evaluates peers and attempts connectivity upgrades.

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -594,17 +594,13 @@ func (a *Agent) startICECheck(ctx context.Context, peer *wirekubev1alpha1.WireKu
 		a.probeDirectEndpoint(peer)
 
 	case myNAT == "symmetric" && peerNAT == "symmetric":
-		switch {
-		case !a.isBirthdayAttackEnabled(peer):
-			a.log.Info("symmetric↔symmetric — birthday attack disabled, staying on relay", "peer", peer.Name)
-			state.State = iceStateFailed
-		case !state.BirthdayTried:
+		if ok, reason := a.canStartBirthdayAttack(peer, state); ok {
 			a.log.Info("symmetric↔symmetric — initiating birthday attack", "peer", peer.Name)
 			state.State = iceStateBirthday
 			state.BirthdayTried = true
 			go a.runBirthdayAttack(ctx, peer)
-		default:
-			a.log.Info("symmetric↔symmetric — birthday attack already attempted, staying on relay", "peer", peer.Name)
+		} else {
+			a.log.Info("symmetric↔symmetric — staying on relay", "peer", peer.Name, "reason", reason)
 			state.State = iceStateFailed
 		}
 	}
@@ -743,6 +739,41 @@ func (a *Agent) isBirthdayAttackEnabled(peer *wirekubev1alpha1.WireKubePeer) boo
 
 	// Default: disabled.
 	return false
+}
+
+// canStartBirthdayAttack is the single gate for launching a birthday attack.
+// Every entry point must consult it so that a mesh with NAT traversal disabled
+// can never spawn a hole-punch goroutine, regardless of how the ICE state
+// machine arrived at the decision. Returns false plus a human-readable reason
+// when any precondition is unmet.
+//
+// All conditions must hold:
+//   - birthday attack explicitly enabled (per-peer annotation or mesh global),
+//   - both ends classified symmetric — a birthday attack only makes sense when
+//     both NATs allocate a fresh port per destination,
+//   - local and peer port-prediction data each have at least one sample (both
+//     sides must be able to predict the other's ports),
+//   - this peer has not already exhausted its single birthday attempt.
+func (a *Agent) canStartBirthdayAttack(peer *wirekubev1alpha1.WireKubePeer, state *peerICEState) (bool, string) {
+	if !a.isBirthdayAttackEnabled(peer) {
+		return false, "birthday attack disabled"
+	}
+	if a.detectedNATType != string(nat.NATSymmetric) {
+		return false, "local NAT is not symmetric"
+	}
+	if peer.Status.NATType != string(nat.NATSymmetric) {
+		return false, "peer NAT is not symmetric"
+	}
+	if a.portPrediction == nil || len(a.portPrediction.SamplePorts) == 0 {
+		return false, "no local port prediction"
+	}
+	if peer.Status.PortPrediction == nil || len(peer.Status.PortPrediction.SamplePorts) == 0 {
+		return false, "no peer port prediction"
+	}
+	if state != nil && state.BirthdayTried {
+		return false, "birthday attack already attempted"
+	}
+	return true, ""
 }
 
 // probeDirectEndpoint switches WG to the peer's direct endpoint for a
@@ -889,7 +920,10 @@ func (a *Agent) evaluateICECheck(ctx context.Context, peer *wirekubev1alpha1.Wir
 			a.enableRelayForPeer(peer)
 		}
 
-		if a.detectedNATType == "symmetric" && peer.Status.NATType == "symmetric" && !state.BirthdayTried {
+		// Route through the same gate as startICECheck so a disabled mesh (or a
+		// pair lacking port prediction) can never start a birthday attack here,
+		// even if the NAT classification changed since the probe began.
+		if ok, _ := a.canStartBirthdayAttack(peer, state); ok {
 			a.log.Info("active probe failed, trying birthday attack", "peer", peer.Name)
 			state.State = iceStateBirthday
 			state.BirthdayTried = true

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -454,9 +454,10 @@ func (a *Agent) runICENegotiation(ctx context.Context, peerList *wirekubev1alpha
 			a.evaluateICECheck(ctx, p, statsByKey)
 
 		case iceStateBirthday:
-			if state.holePunch != nil {
-				a.upgradeToDirect(p, state.holePunch.ListenAddr())
-			}
+			// A birthday attack is running in the background. Its result is
+			// folded in by drainBirthdayResults (which sets holePunch and flips
+			// the state to iceStateConnected), so there is nothing to do here —
+			// this cycle's runICENegotiation always runs before that drain.
 
 		case iceStateFailed:
 			if a.shouldPermanentRelay(p, state) {
@@ -975,17 +976,23 @@ func (a *Agent) evaluateICECheck(ctx context.Context, peer *wirekubev1alpha1.Wir
 	}
 }
 
-// runBirthdayAttack executes the birthday attack for a symmetric↔symmetric peer pair.
-// Runs in a background goroutine.
-func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.WireKubePeer) {
-	state := a.getICEState(peer.Name)
+// birthdayOutcome is the result of a background birthday attack, applied on the
+// sync goroutine by applyBirthdayOutcome. A nil proxy means the attack failed.
+type birthdayOutcome struct {
+	peer  *wirekubev1alpha1.WireKubePeer
+	proxy *holePunchProxy
+}
 
+// runBirthdayAttack executes the birthday attack for a symmetric↔symmetric peer
+// pair. It runs in a background goroutine and MUST NOT touch shared agent state
+// (iceStates, relay maps, etc.): it only computes and hands the result back over
+// birthdayCh, which the sync goroutine drains and applies.
+func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.WireKubePeer) {
 	// Get peer's port prediction and public IP.
 	peerPP := peer.Status.PortPrediction
 	if peerPP == nil || len(peerPP.SamplePorts) == 0 {
 		a.log.Info("no port prediction data available", "peer", peer.Name)
-		state.State = iceStateFailed
-		state.LastCheck = time.Now()
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 
@@ -998,8 +1005,7 @@ func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.Wi
 	}
 	if peerPublicIP == "" {
 		a.log.Info("cannot determine public IP for birthday attack", "peer", peer.Name)
-		state.State = iceStateFailed
-		state.LastCheck = time.Now()
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 
@@ -1018,14 +1024,14 @@ func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.Wi
 	var myPubKey, peerPubKey [32]byte
 	myKeyBytes, err := base64.StdEncoding.DecodeString(a.getOwnPublicKey())
 	if err != nil {
-		state.State = iceStateFailed
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 	copy(myPubKey[:], myKeyBytes)
 
 	peerKeyBytes, err := base64.StdEncoding.DecodeString(peer.Spec.PublicKey)
 	if err != nil {
-		state.State = iceStateFailed
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 	copy(peerPubKey[:], peerKeyBytes)
@@ -1035,8 +1041,7 @@ func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.Wi
 	result, err := nat.BirthdayAttack(ctx, myPubKey, peerPubKey, peerPublicIP, candidatePorts)
 	if err != nil {
 		a.log.Error(err, "birthday attack failed", "peer", peer.Name)
-		state.State = iceStateFailed
-		state.LastCheck = time.Now()
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 
@@ -1045,16 +1050,53 @@ func (a *Agent) runBirthdayAttack(ctx context.Context, peer *wirekubev1alpha1.Wi
 	if err != nil {
 		a.log.Error(err, "birthday attack proxy creation failed", "peer", peer.Name)
 		result.LocalConn.Close()
-		state.State = iceStateFailed
-		state.LastCheck = time.Now()
+		a.reportBirthday(ctx, peer, nil)
 		return
 	}
 
 	go proxy.Run()
-	state.holePunch = proxy
+	a.reportBirthday(ctx, peer, proxy)
+}
+
+// reportBirthday hands a birthday-attack result to the sync goroutine. If the
+// agent is shutting down before the result is drained, a successful proxy is
+// closed here so it is not leaked.
+func (a *Agent) reportBirthday(ctx context.Context, peer *wirekubev1alpha1.WireKubePeer, proxy *holePunchProxy) {
+	select {
+	case a.birthdayCh <- birthdayOutcome{peer: peer, proxy: proxy}:
+	case <-ctx.Done():
+		if proxy != nil {
+			proxy.Close()
+		}
+	}
+}
+
+// drainBirthdayResults applies all completed background birthday attacks. Called
+// only from sync (the sole writer of the ICE/relay maps).
+func (a *Agent) drainBirthdayResults() {
+	for {
+		select {
+		case out := <-a.birthdayCh:
+			a.applyBirthdayOutcome(out)
+		default:
+			return
+		}
+	}
+}
+
+// applyBirthdayOutcome folds a birthday-attack result into agent state. Runs on
+// the sync goroutine.
+func (a *Agent) applyBirthdayOutcome(out birthdayOutcome) {
+	state := a.getICEState(out.peer.Name)
+	if out.proxy == nil {
+		state.State = iceStateFailed
+		state.LastCheck = time.Now()
+		return
+	}
+	state.holePunch = out.proxy
 	state.State = iceStateConnected
-	a.upgradeToDirect(peer, proxy.ListenAddr())
-	a.log.Info("hole-punched path established", "peer", peer.Name, "proxyAddr", proxy.ListenAddr())
+	a.upgradeToDirect(out.peer, out.proxy.ListenAddr())
+	a.log.Info("hole-punched path established", "peer", out.peer.Name, "proxyAddr", out.proxy.ListenAddr())
 }
 
 // upgradeToDirect switches a peer from relay to direct transport.
@@ -1165,9 +1207,10 @@ func (a *Agent) unstableProbeBackoff() time.Duration {
 // directFailoverProbeCooldown set by deferDirectReprobe — intended, because a
 // NAT-type change invalidates the prior failover assumption.
 //
-// Peers mid birthday-attack are skipped: their *peerICEState is concurrently
-// mutated by the background runBirthdayAttack goroutine (a pre-existing aspect of
-// the ICE state machine), so the sync goroutine must not also write it here.
+// Peers mid birthday-attack are skipped: a pending background result will set
+// their state via drainBirthdayResults, so re-arming the probe backoff now would
+// be premature (it would race the imminent relay→direct upgrade in intent, not
+// in memory — all ICE-state writes are on the sync goroutine).
 func (a *Agent) clearDirectReprobeBackoff() {
 	for _, s := range a.iceStates {
 		if s.State == iceStateBirthday {

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -76,6 +76,12 @@ var virtualIfacePrefixes = []string{
 	"br-", "virbr", "wg", "wire_kube", "lxc",
 }
 
+// cgnatNet is the RFC 6598 shared address space (100.64.0.0/10) used by
+// carrier-grade NAT. net.IP.IsPrivate does NOT include this range, yet it is
+// not externally routable, so it must never be advertised as a reflexive
+// candidate. Double-NAT/CGNAT routers hand these addresses out (e.g. via UPnP).
+var _, cgnatNet, _ = net.ParseCIDR("100.64.0.0/10")
+
 // peerICEState tracks ICE negotiation state for a single peer.
 type peerICEState struct {
 	State         string
@@ -221,8 +227,11 @@ func (a *Agent) gatherICECandidates(epResult *EndpointResult) []wirekubev1alpha1
 		})
 	}
 
-	// Server-reflexive candidate: STUN-discovered public endpoint.
-	if epResult != nil && epResult.Endpoint != "" {
+	// Server-reflexive candidate: STUN/portmap-discovered endpoint. Publish it
+	// only when the discovered address is externally routable — a private or
+	// CGNAT address (e.g. a UPnP external IP behind double-NAT) must never be
+	// advertised as srflx, or peers will attempt direct paths that cannot work.
+	if epResult != nil && isPublicCandidateEndpoint(epResult.Endpoint) {
 		prio := int32(200)
 		if epResult.NATType == nat.NATSymmetric {
 			prio = 50 // low priority — mapped port is unstable
@@ -1405,4 +1414,31 @@ func isLocalhostEndpoint(ep string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// isPublicCandidateEndpoint reports whether endpoint ("host:port") has a host IP
+// that is externally routable and therefore valid as a server-reflexive (srflx)
+// ICE candidate. It rejects loopback, link-local, multicast, unspecified, the
+// IPv4 broadcast address (all excluded by !IsGlobalUnicast), RFC 1918 / IPv6 ULA
+// private addresses, and CGNAT shared address space (100.64.0.0/10). The CGNAT
+// range looks public to net.IP.IsPrivate but is handed out by double-NAT/CGNAT
+// routers and is unreachable from other peers, so a private or CGNAT address
+// must never be published as reflexive. IPv4-mapped IPv6 addresses are
+// normalized via To4() before the CGNAT check.
+func isPublicCandidateEndpoint(endpoint string) bool {
+	host, _, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if !ip.IsGlobalUnicast() || ip.IsPrivate() {
+		return false
+	}
+	if ip4 := ip.To4(); ip4 != nil && cgnatNet != nil && cgnatNet.Contains(ip4) {
+		return false
+	}
+	return true
 }

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -274,78 +274,82 @@ func TestPreferredTransportForPeer(t *testing.T) {
 	}
 }
 
-func TestPublishedTransportForPeerPrefersObservedDirectPath(t *testing.T) {
-	wg := &fakeWGEngine{lastDirect: map[string]int64{
-		"pub-a": time.Now().Add(-500 * time.Millisecond).UnixNano(),
-	}}
-	a := &Agent{
-		wgMgr:                 wg,
-		relayedPeers:          map[string]bool{"peer-a": true},
-		handshakeValidWindow:  45 * time.Second,
-		directConnectedWindow: 3 * time.Minute,
-		healthProbeTimeout:    5 * time.Second,
-	}
-	peer := &wirekubev1alpha1.WireKubePeer{
-		ObjectMeta: metav1.ObjectMeta{Name: "peer-a"},
-		Spec: wirekubev1alpha1.WireKubePeerSpec{
-			PublicKey: "pub-a",
-		},
-	}
-	stats := map[string]wireguard.PeerStats{
-		"pub-a": {
-			PublicKeyB64:   "pub-a",
-			LastHandshake:  time.Now().Add(-5 * time.Second),
-			ActualEndpoint: "203.0.113.10:51820",
-		},
-	}
-
-	if got := a.publishedTransportForPeer(peer, stats); got != "direct" {
-		t.Fatalf("publishedTransportForPeer() = %q, want direct for observed direct dataplane", got)
-	}
-}
-
-// TestPublishedTransportForPeerReadsPathMonitor asserts the new status
-// contract: publishedTransportForPeer reflects whatever PathMonitor
-// currently says the peer's mode is. Direct and Warm both surface as
-// "direct" (we are using, or trying, the direct leg); only PathModeRelay
-// surfaces as "relay" (direct has been given up on). The legacy path —
-// inspecting WG's ActualEndpoint for "127.0.0.1:..." (the old UDPProxy
-// signal) — is gone along with UDPProxy itself.
+// TestPublishedTransportForPeerReadsPathMonitor asserts the status contract:
+// only PathModeDirect (confirmed direct via fresh direct-receive evidence) is
+// reported as "direct". PathModeWarm (direct unproven / being demoted),
+// PathUnknown (not yet evaluated), and PathModeRelay all report "relay", so the
+// status never overstates a probing/unknown path as a confirmed direct one.
 func TestPublishedTransportForPeerReadsPathMonitor(t *testing.T) {
-	// Drive a PathMonitor into PathModeRelay by setting its backoff
-	// deadline into the past and never feeding a direct RX.
-	rx := &fakeRX{last: map[string]int64{}}
-	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
-	pm := NewPathMonitor(logr.Discard(), rx, PathMonitorConfig{
-		WarmStall:  100 * time.Millisecond,
-		RelayStall: 100 * time.Millisecond, // short so the transition to Relay happens fast
-		PromoteAge: 50 * time.Millisecond,
-		RelayRetry: 5 * time.Second, // long so we stay in Relay
-	}, clk.now)
-	// Drive: Relay (first Evaluate) → Warm (forced probe) → Relay (stall).
-	pm.Evaluate("peer-a", "pub-a", true) // → Warm
-	clk.advance(200 * time.Millisecond)
-	pm.Evaluate("peer-a", "pub-a", false) // Warm → Relay
-
-	a := &Agent{pathMonitor: pm}
-	peer := &wirekubev1alpha1.WireKubePeer{
-		ObjectMeta: metav1.ObjectMeta{Name: "peer-a"},
-		Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: "pub-a"},
-	}
-	if got := a.publishedTransportForPeer(peer, nil); got != "relay" {
-		t.Fatalf("publishedTransportForPeer() = %q, want relay", got)
+	assertTransport := func(t *testing.T, pm *PathMonitor, peerName, pubKey, want string) {
+		t.Helper()
+		a := &Agent{pathMonitor: pm}
+		peer := &wirekubev1alpha1.WireKubePeer{
+			ObjectMeta: metav1.ObjectMeta{Name: peerName},
+			Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: pubKey},
+		}
+		if got := a.publishedTransportForPeer(peer, nil); got != want {
+			t.Fatalf("publishedTransportForPeer(%s) = %q, want %q", peerName, got, want)
+		}
 	}
 
-	// A second peer the monitor has never seen → "direct" (safe default;
-	// the sync loop will catch up on the next tick and place the peer on
-	// Relay if appropriate).
-	other := &wirekubev1alpha1.WireKubePeer{
-		ObjectMeta: metav1.ObjectMeta{Name: "peer-b"},
-		Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: "pub-b"},
+	newMon := func() (*PathMonitor, *fakeRX, *fakeClock) {
+		rx := &fakeRX{last: map[string]int64{}}
+		clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+		pm := NewPathMonitor(logr.Discard(), rx, PathMonitorConfig{
+			WarmStall:  100 * time.Millisecond,
+			RelayStall: 100 * time.Millisecond,
+			PromoteAge: 50 * time.Millisecond,
+			RelayRetry: 5 * time.Second,
+		}, clk.now)
+		return pm, rx, clk
 	}
-	if got := a.publishedTransportForPeer(other, nil); got != "direct" {
-		t.Fatalf("publishedTransportForPeer(new peer) = %q, want direct (unknown)", got)
-	}
+
+	// PathModeDirect: forced probe → Warm, then fresh direct RX promotes to Direct.
+	t.Run("direct reports direct", func(t *testing.T) {
+		pm, rx, clk := newMon()
+		pm.Evaluate("p", "k", true) // Relay → Warm
+		rx.last["k"] = clk.now().UnixNano()
+		clk.advance(10 * time.Millisecond) // still within promoteAge
+		if got := pm.Evaluate("p", "k", false); got != PathModeDirect {
+			t.Fatalf("precondition: mode = %s, want Direct", got)
+		}
+		assertTransport(t, pm, "p", "k", "direct")
+	})
+
+	// PathModeWarm: forced probe enters Warm; assert before any promotion.
+	t.Run("warm reports relay", func(t *testing.T) {
+		pm, _, _ := newMon()
+		if got := pm.Evaluate("p", "k", true); got != PathModeWarm {
+			t.Fatalf("precondition: mode = %s, want Warm", got)
+		}
+		assertTransport(t, pm, "p", "k", "relay")
+	})
+
+	// PathModeRelay: Warm → Relay after the stall window with no direct RX.
+	t.Run("relay reports relay", func(t *testing.T) {
+		pm, _, clk := newMon()
+		pm.Evaluate("p", "k", true) // Relay → Warm
+		clk.advance(200 * time.Millisecond)
+		if got := pm.Evaluate("p", "k", false); got != PathModeRelay { // Warm → Relay
+			t.Fatalf("precondition: mode = %s, want Relay", got)
+		}
+		assertTransport(t, pm, "p", "k", "relay")
+	})
+
+	// PathUnknown: a peer the monitor has never evaluated → conservative relay.
+	t.Run("unknown peer reports relay", func(t *testing.T) {
+		pm, _, _ := newMon()
+		assertTransport(t, pm, "never-seen", "nk", "relay")
+	})
+
+	// Nil pathMonitor (test-only literal) also reports the conservative relay.
+	t.Run("nil pathMonitor reports relay", func(t *testing.T) {
+		a := &Agent{}
+		peer := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "p"}}
+		if got := a.publishedTransportForPeer(peer, nil); got != "relay" {
+			t.Fatalf("nil pathMonitor = %q, want relay", got)
+		}
+	})
 }
 
 func TestHasPendingRestartRelayRecovery(t *testing.T) {

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -1232,5 +1233,113 @@ func TestRecoverICEStateFromWGWithoutPreservedInterfaceFallsBackToRelay(t *testi
 	}
 	if !state.LastCheck.IsZero() {
 		t.Fatalf("LastCheck = %v, want zero for immediate reprobe", state.LastCheck)
+	}
+}
+
+func TestIsPublicCandidateEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		ep   string
+		want bool
+	}{
+		{"public v4", "203.0.113.10:51820", true},
+		{"public v6", "[2606:4700:4700::1111]:51820", true},
+		{"public 100-block below cgnat", "100.63.0.1:51820", true},
+		{"public 100-block above cgnat", "100.128.0.1:51820", true},
+		{"rfc1918 192.168", "192.168.55.87:51822", false},
+		{"rfc1918 10", "10.0.0.5:51820", false},
+		{"rfc1918 172.16", "172.16.0.1:51820", false},
+		{"cgnat 100.64 low", "100.64.1.2:51820", false},
+		{"cgnat 100.127 high", "100.127.255.255:51820", false},
+		{"loopback", "127.0.0.1:51820", false},
+		{"link-local v4", "169.254.1.1:51820", false},
+		{"multicast v4", "224.0.0.1:51820", false},
+		{"unspecified", "0.0.0.0:51820", false},
+		{"ipv6 ula", "[fc00::1]:51820", false},
+		{"ipv6 link-local", "[fe80::1]:51820", false},
+		{"missing port", "203.0.113.10", false},
+		{"empty", "", false},
+		{"hostname not ip", "example.com:51820", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPublicCandidateEndpoint(tt.ep); got != tt.want {
+				t.Errorf("isPublicCandidateEndpoint(%q) = %v, want %v", tt.ep, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGatherICECandidatesFiltersPrivateSrflx verifies that a private or CGNAT
+// discovered endpoint (e.g. a UPnP external IP behind double-NAT) is NOT
+// advertised as a server-reflexive candidate, while a genuinely public one is —
+// at full priority for stable NAT and reduced priority for symmetric NAT.
+func TestGatherICECandidatesFiltersPrivateSrflx(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: "10.0.0.5"},
+		}},
+	}
+	k8sClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	a := &Agent{
+		client:   k8sClient,
+		nodeName: "test-node",
+		wgMgr:    &fakeWGEngine{},
+		log:      logr.Discard(),
+	}
+
+	srflxOf := func(cands []wirekubev1alpha1.ICECandidate) *wirekubev1alpha1.ICECandidate {
+		for i := range cands {
+			if cands[i].Type == candidateTypeSrflx {
+				return &cands[i]
+			}
+		}
+		return nil
+	}
+	hasHost := func(cands []wirekubev1alpha1.ICECandidate) bool {
+		for _, c := range cands {
+			if c.Type == candidateTypeHost {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Private (UPnP-style) discovered endpoint: no srflx candidate, but the host
+	// candidate (LAN IP) is still published for same-NAT direct.
+	got := a.gatherICECandidates(&EndpointResult{Endpoint: "192.168.55.87:51822", Method: MethodUPnP})
+	if s := srflxOf(got); s != nil {
+		t.Fatalf("private endpoint published as srflx: %+v", *s)
+	}
+	if !hasHost(got) {
+		t.Fatalf("host candidate missing for private endpoint; got %+v", got)
+	}
+
+	// CGNAT (RFC 6598) discovered endpoint — looks public to IsPrivate but is not
+	// routable; the real-world double-NAT case. Must not be published as srflx.
+	got = a.gatherICECandidates(&EndpointResult{Endpoint: "100.64.1.2:51822", Method: MethodUPnP})
+	if s := srflxOf(got); s != nil {
+		t.Fatalf("CGNAT endpoint published as srflx: %+v", *s)
+	}
+
+	// Public endpoint: srflx published at full priority.
+	got = a.gatherICECandidates(&EndpointResult{Endpoint: "203.0.113.10:51822", Method: MethodSTUN})
+	s := srflxOf(got)
+	if s == nil {
+		t.Fatalf("public endpoint not published as srflx; got %+v", got)
+	}
+	if s.Address != "203.0.113.10:51822" || s.Priority != 200 {
+		t.Fatalf("public srflx = %+v, want addr 203.0.113.10:51822 priority 200", *s)
+	}
+
+	// Public endpoint behind symmetric NAT: srflx published at low priority.
+	got = a.gatherICECandidates(&EndpointResult{Endpoint: "203.0.113.10:51822", Method: MethodSTUN, NATType: nat.NATSymmetric})
+	if s := srflxOf(got); s == nil || s.Priority != 50 {
+		t.Fatalf("symmetric srflx = %+v, want priority 50", s)
 	}
 }

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -44,6 +44,7 @@ func (f *fakeWGEngine) GetStats() ([]wireguard.PeerStats, error) { return f.stat
 func (f *fakeWGEngine) SetAddress(string) error                  { return nil }
 func (f *fakeWGEngine) SetPreferredSrc(string)                   {}
 func (f *fakeWGEngine) SyncRoutes([]string) error                { return nil }
+func (f *fakeWGEngine) EnsureRoutingRules() error                { return nil }
 func (f *fakeWGEngine) AddRoute(string) error                    { return nil }
 func (f *fakeWGEngine) DelRoute(string) error                    { return nil }
 func (f *fakeWGEngine) SetPeerPath(_ string, mode wireguard.PathMode, _ string) error {

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -1418,6 +1418,80 @@ func TestStartICECheckProbesUnclassifiedPairs(t *testing.T) {
 	}
 }
 
+func TestShouldPermanentRelayExcludesUnknownNAT(t *testing.T) {
+	mkPeer := func(natType string) *wirekubev1alpha1.WireKubePeer {
+		p := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "remote"}}
+		p.Status.NATType = natType
+		return p
+	}
+	cases := []struct {
+		name    string
+		myNAT   string
+		peerNAT string
+		wantPin bool
+	}{
+		{"unknown × unknown not pinned", "", "", false},
+		{"unknown × symmetric not pinned", "", "symmetric", false},
+		{"cone × unknown not pinned", "cone", "", false},
+		{"port-restricted-cone × symmetric pinned", "port-restricted-cone", "symmetric", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Agent{detectedNATType: tc.myNAT}
+			if got := a.shouldPermanentRelay(mkPeer(tc.peerNAT), &peerICEState{}); got != tc.wantPin {
+				t.Fatalf("shouldPermanentRelay = %v, want %v", got, tc.wantPin)
+			}
+		})
+	}
+}
+
+// TestEvaluateICECheckBacksOffUnstableNATAfterRepeatedFailures verifies that an
+// unstable/unknown-NAT pair with no direct receive, after repeated probe
+// failures, is held on relay for the long unstable backoff instead of being
+// re-probed every relayRetry.
+func TestEvaluateICECheckBacksOffUnstableNATAfterRepeatedFailures(t *testing.T) {
+	a := &Agent{
+		log:             logr.Discard(),
+		wgMgr:           &fakeWGEngine{lastDirect: map[string]int64{}}, // LastDirectReceive → 0
+		detectedNATType: "",                                            // our NAT still unclassified → pair unstable
+		relayRetry:      30 * time.Second,
+		directProbing:   map[string]bool{"remote": true},
+		relayedPeers:    map[string]bool{},
+		directEndpoints: map[string]string{},
+		iceStates:       map[string]*peerICEState{},
+	}
+	peer := &wirekubev1alpha1.WireKubePeer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "remote",
+			Annotations: map[string]string{"wirekube.io/birthday-attack": "disabled"}, // avoid client lookup
+		},
+		Spec: wirekubev1alpha1.WireKubePeerSpec{PublicKey: "remote-key"},
+	}
+	peer.Status.NATType = "cone"
+
+	state := a.getICEState("remote")
+	state.State = iceStateChecking
+	state.ProbeFailCount = unstableProbeFailThreshold - 1 // ++ in evaluateICECheck reaches the threshold
+	state.LastCheck = time.Now().Add(-activeProbeWait - time.Second)
+	a.setICEState("remote", state)
+
+	a.evaluateICECheck(context.Background(), peer, map[string]wireguard.PeerStats{})
+
+	got := a.getICEState("remote")
+	if got.State != iceStateFailed {
+		t.Fatalf("state = %s, want %s", got.State, iceStateFailed)
+	}
+	if got.NextProbeAfter.IsZero() || time.Until(got.NextProbeAfter) < 9*time.Minute {
+		t.Fatalf("NextProbeAfter in %v, want a long (~10m) backoff", time.Until(got.NextProbeAfter))
+	}
+
+	// A NAT re-classification clears the backoff so the peer can re-probe.
+	a.clearDirectReprobeBackoff()
+	if !a.getICEState("remote").NextProbeAfter.IsZero() {
+		t.Fatalf("clearDirectReprobeBackoff did not reset NextProbeAfter")
+	}
+}
+
 func TestCanStartBirthdayAttack(t *testing.T) {
 	localPP := &nat.PortPrediction{SamplePorts: []int{1000, 1100, 1200}}
 	peerPP := &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{2000, 2100, 2200}}

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -1344,6 +1344,76 @@ func TestGatherICECandidatesFiltersPrivateSrflx(t *testing.T) {
 	}
 }
 
+func TestIsStableDirectNAT(t *testing.T) {
+	tests := []struct {
+		natType string
+		want    bool
+	}{
+		{string(nat.NATOpen), true},
+		{string(nat.NATCone), true},
+		{"", false}, // unknown/unclassified must NOT be treated as stable
+		{string(nat.NATSymmetric), false},
+		{string(nat.NATPortRestrictedCone), false},
+		{"something-unexpected", false},
+	}
+	for _, tt := range tests {
+		name := tt.natType
+		if name == "" {
+			name = "unknown"
+		}
+		t.Run(name, func(t *testing.T) {
+			if got := isStableDirectNAT(tt.natType); got != tt.want {
+				t.Errorf("isStableDirectNAT(%q) = %v, want %v", tt.natType, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestStartICECheckProbesUnclassifiedPairs locks the behavior-preservation
+// invariant of Phase 4: making unknown ("") an explicit switch case must NOT
+// stop unclassified or port-restricted-cone pairs from being probed. Every
+// non-(both-symmetric) pair must still initiate a direct probe. This guards the
+// invariant against a future Phase 6 change to the default arm.
+func TestStartICECheckProbesUnclassifiedPairs(t *testing.T) {
+	cases := []struct {
+		name    string
+		myNAT   string
+		peerNAT string
+	}{
+		{"unknown × cone", "", string(nat.NATCone)},
+		{"cone × unknown", string(nat.NATCone), ""},
+		{"unknown × unknown", "", ""},
+		{"port-restricted-cone × cone", string(nat.NATPortRestrictedCone), string(nat.NATCone)},
+		{"cone × cone (control)", string(nat.NATCone), string(nat.NATCone)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Agent{
+				log:             logr.Discard(),
+				wgMgr:           &fakeWGEngine{lastDirect: map[string]int64{}},
+				detectedNATType: tc.myNAT,
+				directProbing:   map[string]bool{},
+				directEndpoints: map[string]string{},
+				iceStates:       map[string]*peerICEState{},
+			}
+			peer := &wirekubev1alpha1.WireKubePeer{
+				ObjectMeta: metav1.ObjectMeta{Name: "remote"},
+				Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: "remote-key", Endpoint: "203.0.113.10:51820"},
+			}
+			peer.Status.NATType = tc.peerNAT
+
+			a.startICECheck(context.Background(), peer, map[string]wireguard.PeerStats{})
+
+			if !a.directProbing["remote"] {
+				t.Errorf("directProbing[remote] = false, want true (pair must still probe)")
+			}
+			if got := a.getICEState("remote").State; got != iceStateChecking {
+				t.Errorf("state = %s, want %s", got, iceStateChecking)
+			}
+		})
+	}
+}
+
 func TestCanStartBirthdayAttack(t *testing.T) {
 	localPP := &nat.PortPrediction{SamplePorts: []int{1000, 1100, 1200}}
 	peerPP := &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{2000, 2100, 2200}}

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -1343,3 +1343,146 @@ func TestGatherICECandidatesFiltersPrivateSrflx(t *testing.T) {
 		t.Fatalf("symmetric srflx = %+v, want priority 50", s)
 	}
 }
+
+func TestCanStartBirthdayAttack(t *testing.T) {
+	localPP := &nat.PortPrediction{SamplePorts: []int{1000, 1100, 1200}}
+	peerPP := &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{2000, 2100, 2200}}
+
+	// newPeer builds a remote peer. A non-empty annotation drives
+	// isBirthdayAttackEnabled directly (per-peer annotation has highest
+	// priority), so these cases never touch the k8s client.
+	newPeer := func(ann, natType string, pp *wirekubev1alpha1.PortPrediction) *wirekubev1alpha1.WireKubePeer {
+		p := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "remote"}}
+		if ann != "" {
+			p.Annotations = map[string]string{"wirekube.io/birthday-attack": ann}
+		}
+		p.Status.NATType = natType
+		p.Status.PortPrediction = pp
+		return p
+	}
+
+	tests := []struct {
+		name     string
+		localNAT string
+		localPP  *nat.PortPrediction
+		ann      string
+		peerNAT  string
+		peerPP   *wirekubev1alpha1.PortPrediction
+		tried    bool
+		want     bool
+	}{
+		{"all conditions met", "symmetric", localPP, "enabled", "symmetric", peerPP, false, true},
+		{"disabled by annotation", "symmetric", localPP, "disabled", "symmetric", peerPP, false, false},
+		{"local NAT not symmetric", "cone", localPP, "enabled", "symmetric", peerPP, false, false},
+		{"peer NAT unknown", "symmetric", localPP, "enabled", "", peerPP, false, false},
+		{"peer NAT cone", "symmetric", localPP, "enabled", "cone", peerPP, false, false},
+		{"no local port prediction", "symmetric", nil, "enabled", "symmetric", peerPP, false, false},
+		{"empty local port prediction", "symmetric", &nat.PortPrediction{}, "enabled", "symmetric", peerPP, false, false},
+		{"no peer port prediction", "symmetric", localPP, "enabled", "symmetric", nil, false, false},
+		{"birthday already tried", "symmetric", localPP, "enabled", "symmetric", peerPP, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Agent{detectedNATType: tt.localNAT, portPrediction: tt.localPP}
+			peer := newPeer(tt.ann, tt.peerNAT, tt.peerPP)
+			got, reason := a.canStartBirthdayAttack(peer, &peerICEState{BirthdayTried: tt.tried})
+			if got != tt.want {
+				t.Fatalf("canStartBirthdayAttack() = %v (reason %q), want %v", got, reason, tt.want)
+			}
+			if !got && reason == "" {
+				t.Errorf("denied but no reason given")
+			}
+			if got && reason != "" {
+				t.Errorf("allowed but reason = %q, want empty", reason)
+			}
+		})
+	}
+}
+
+// TestCanStartBirthdayAttackDisabledByDefault is the safety guarantee: with
+// WireKubeMesh.spec.natTraversal absent, no birthday attack may start even when
+// both ends are symmetric and have port prediction. This is the condition under
+// which the previously-unguarded evaluateICECheck entry point could spawn a
+// hole-punch goroutine.
+func TestCanStartBirthdayAttackDisabledByDefault(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+	if err := wirekubev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(wirekube): %v", err)
+	}
+	// Mesh with no NATTraversal block → birthday attack disabled by default.
+	mesh := &wirekubev1alpha1.WireKubeMesh{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	k8sClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(mesh).Build()
+
+	a := &Agent{
+		client:          k8sClient,
+		nodeName:        "test-node",
+		detectedNATType: "symmetric",
+		portPrediction:  &nat.PortPrediction{SamplePorts: []int{1000, 1100}},
+	}
+	// Remote peer is fully birthday-eligible EXCEPT that nothing enables it.
+	peer := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "remote"}}
+	peer.Status.NATType = "symmetric"
+	peer.Status.PortPrediction = &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{2000, 2100}}
+
+	if ok, reason := a.canStartBirthdayAttack(peer, &peerICEState{}); ok {
+		t.Fatalf("birthday attack allowed with natTraversal absent; want disabled (reason=%q)", reason)
+	}
+}
+
+// TestEvaluateICECheckDoesNotStartBirthdayWhenDisabled is the regression anchor
+// for the previously-unguarded entry point. When an active probe fails for a
+// symmetric↔symmetric pair but NAT traversal is disabled, evaluateICECheck must
+// fall back to relay (iceStateFailed) and must NOT spawn a birthday-attack
+// goroutine. This locks the fix against a future refactor re-inlining the check.
+func TestEvaluateICECheckDoesNotStartBirthdayWhenDisabled(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+	if err := wirekubev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(wirekube): %v", err)
+	}
+	mesh := &wirekubev1alpha1.WireKubeMesh{ObjectMeta: metav1.ObjectMeta{Name: "default"}} // no NATTraversal
+	k8sClient := ctrlclientfake.NewClientBuilder().WithScheme(scheme).WithObjects(mesh).Build()
+
+	a := &Agent{
+		client:          k8sClient,
+		nodeName:        "test-node",
+		log:             logr.Discard(),
+		wgMgr:           &fakeWGEngine{lastDirect: map[string]int64{}},
+		detectedNATType: "symmetric",
+		portPrediction:  &nat.PortPrediction{SamplePorts: []int{1000, 1100}},
+		directProbing:   map[string]bool{"remote": true},
+		iceStates:       map[string]*peerICEState{},
+	}
+	peer := &wirekubev1alpha1.WireKubePeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "remote"},
+		Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: "remote-key"},
+	}
+	peer.Status.NATType = "symmetric"
+	peer.Status.PortPrediction = &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{2000, 2100}}
+
+	// Active probe in flight, probe window elapsed, peer absent from stats (no
+	// fresh handshake) → evaluateICECheck reaches the birthday decision, which
+	// the gate denies, then falls back to relay.
+	state := a.getICEState("remote")
+	state.State = iceStateChecking
+	state.LastCheck = time.Now().Add(-activeProbeWait - time.Second)
+	a.setICEState("remote", state)
+
+	a.evaluateICECheck(context.Background(), peer, map[string]wireguard.PeerStats{})
+
+	got := a.getICEState("remote")
+	if got.State != iceStateFailed {
+		t.Fatalf("state = %s, want %s (relay fallback, no birthday)", got.State, iceStateFailed)
+	}
+	if got.BirthdayTried {
+		t.Errorf("BirthdayTried = true, want false (no birthday attempt when disabled)")
+	}
+	if got.holePunch != nil {
+		t.Errorf("holePunch set, want nil (no hole-punch goroutine spawned)")
+	}
+}

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -220,9 +220,11 @@ func (a *Agent) updateMetrics(ctx context.Context, peerList *wirekubev1alpha1.Wi
 	a.dropStaleMetricLabels(currentPeers)
 }
 
-// measurePeerLatency runs a single ICMP ping to each connected peer and
-// records the round-trip time. Skips peers without a reachable AllowedIP.
-func (a *Agent) measurePeerLatency(peerList *wirekubev1alpha1.WireKubePeerList) {
+// measurePeerLatency runs a single ICMP ping to each connected peer and records
+// the round-trip time. Skips peers without a reachable AllowedIP. It runs in a
+// background goroutine and must not touch shared agent maps: the relayed-peer
+// set is passed in as a snapshot taken on the sync goroutine.
+func (a *Agent) measurePeerLatency(peerList *wirekubev1alpha1.WireKubePeerList, relayed map[string]bool) {
 	myPeerName := a.nodeName
 
 	for i := range peerList.Items {
@@ -248,7 +250,7 @@ func (a *Agent) measurePeerLatency(peerList *wirekubev1alpha1.WireKubePeerList) 
 		}
 
 		transport := "direct"
-		if a.relayedPeers[p.Name] {
+		if relayed[p.Name] {
 			transport = "relay"
 		}
 

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -174,11 +174,11 @@ func (a *Agent) updateMetrics(ctx context.Context, peerList *wirekubev1alpha1.Wi
 		}
 
 		// Align the metric with WireKubePeer.status.connections: PathMonitor
-		// is the single source of truth for transport mode. The legacy
-		// relayedPeers map stays populated by ICE for its own bookkeeping
-		// but can lag behind the datapath by many seconds, which made the
-		// Grafana dashboard show Relay while the bind was actually sending
-		// direct (or bimodal Warm, which also counts as "direct").
+		// is the single source of truth for transport mode. Only a confirmed
+		// direct path (PathModeDirect) counts as direct here; PathModeWarm,
+		// PathUnknown, and PathModeRelay all count as relay. The legacy
+		// relayedPeers map stays populated by ICE for its own bookkeeping but
+		// can lag behind the datapath, so it is intentionally not used here.
 		isRelayed := a.publishedTransportForPeer(p, nil) == "relay"
 		connected := float64(0)
 		if a.peerTransportUsable(p, wgStatsByKey) {

--- a/pkg/agent/nat/stun.go
+++ b/pkg/agent/nat/stun.go
@@ -148,6 +148,12 @@ type STUNResult struct {
 	Endpoint       string
 	NATType        NATType
 	PortPrediction *PortPrediction
+	// ServersResponded / ServersTotal record how many of the queried STUN
+	// servers answered. When only one responds, symmetric NAT cannot be
+	// detected (NATType is NATUnknown), so callers use these counts to tell a
+	// partial success (retry next cycle) apart from a total failure.
+	ServersResponded int
+	ServersTotal     int
 }
 
 // ErrSymmetricNAT is returned when Symmetric NAT is detected.
@@ -207,13 +213,21 @@ func DiscoverPublicEndpointWithNATType(ctx context.Context, localPort int, stunS
 		results = append(results, stunResponse{endpoint: endpoint, ip: ip, port: port})
 	}
 
-	if len(results) == 0 {
+	total := len(stunServers)
+	responded := len(results)
+
+	if responded == 0 {
 		return nil, fmt.Errorf("all STUN servers failed, last error: %w", lastErr)
 	}
 
-	if len(results) == 1 {
+	if responded == 1 {
 		log.Printf("[stun] warning: only 1 STUN server responded — cannot detect Symmetric NAT (need 2+ servers)\n")
-		return &STUNResult{Endpoint: results[0].endpoint, NATType: NATUnknown}, nil
+		return &STUNResult{
+			Endpoint:         results[0].endpoint,
+			NATType:          NATUnknown,
+			ServersResponded: responded,
+			ServersTotal:     total,
+		}, nil
 	}
 
 	// Collect all observed ports for port prediction.
@@ -243,8 +257,10 @@ func DiscoverPublicEndpointWithNATType(ctx context.Context, localPort int, stunS
 			nat = NATOpen
 		}
 		return &STUNResult{
-			Endpoint: results[0].endpoint,
-			NATType:  nat,
+			Endpoint:         results[0].endpoint,
+			NATType:          nat,
+			ServersResponded: responded,
+			ServersTotal:     total,
 		}, nil
 	}
 
@@ -254,9 +270,11 @@ func DiscoverPublicEndpointWithNATType(ctx context.Context, localPort int, stunS
 		samplePorts, pp.Increment, pp.Jitter)
 
 	return &STUNResult{
-		Endpoint:       results[0].endpoint,
-		NATType:        NATSymmetric,
-		PortPrediction: &pp,
+		Endpoint:         results[0].endpoint,
+		NATType:          NATSymmetric,
+		PortPrediction:   &pp,
+		ServersResponded: responded,
+		ServersTotal:     total,
 	}, nil
 }
 

--- a/pkg/agent/nat_reclassify_test.go
+++ b/pkg/agent/nat_reclassify_test.go
@@ -1,0 +1,180 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/wirekube/wirekube/pkg/agent/nat"
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+)
+
+func TestClassificationFromSTUN(t *testing.T) {
+	if c := classificationFromSTUN(nil, errors.New("boom")); c.NATType != nat.NATUnknown || c.Error == "" {
+		t.Fatalf("error case = %+v, want unknown + error", c)
+	}
+	if c := classificationFromSTUN(nil, nil); c.NATType != nat.NATUnknown || c.Error == "" {
+		t.Fatalf("nil result = %+v, want unknown + error", c)
+	}
+	// 1 of 2 responded → unknown with a descriptive (retryable) error.
+	c := classificationFromSTUN(&nat.STUNResult{NATType: nat.NATUnknown, ServersResponded: 1, ServersTotal: 2}, nil)
+	if c.NATType != nat.NATUnknown || c.Error == "" {
+		t.Fatalf("partial success = %+v, want unknown + error", c)
+	}
+	// 2 of 2 → cone, no error.
+	c = classificationFromSTUN(&nat.STUNResult{NATType: nat.NATCone, ServersResponded: 2, ServersTotal: 2}, nil)
+	if c.NATType != nat.NATCone || c.Error != "" {
+		t.Fatalf("cone = %+v, want cone, no error", c)
+	}
+	// symmetric carries port prediction through.
+	pp := &nat.PortPrediction{SamplePorts: []int{1, 2}}
+	c = classificationFromSTUN(&nat.STUNResult{NATType: nat.NATSymmetric, PortPrediction: pp, ServersResponded: 2, ServersTotal: 2}, nil)
+	if c.NATType != nat.NATSymmetric || c.PortPrediction == nil {
+		t.Fatalf("symmetric = %+v, want symmetric + port prediction", c)
+	}
+}
+
+func newReclassifyAgent(t *testing.T, peer *wirekubev1alpha1.WireKubePeer) *Agent {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core): %v", err)
+	}
+	if err := wirekubev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(wirekube): %v", err)
+	}
+	cb := ctrlclientfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&wirekubev1alpha1.WireKubePeer{})
+	if peer != nil {
+		cb = cb.WithObjects(peer)
+	}
+	return &Agent{client: cb.Build(), nodeName: "test-node", log: logr.Discard()}
+}
+
+func ownPeer(natType string, withPortPrediction bool) *wirekubev1alpha1.WireKubePeer {
+	p := &wirekubev1alpha1.WireKubePeer{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	p.Status.NATType = natType
+	if withPortPrediction {
+		p.Status.PortPrediction = &wirekubev1alpha1.PortPrediction{SamplePorts: []int32{100, 200}}
+	}
+	return p
+}
+
+func readOwnPeer(t *testing.T, a *Agent) *wirekubev1alpha1.WireKubePeer {
+	t.Helper()
+	p := &wirekubev1alpha1.WireKubePeer{}
+	if err := a.client.Get(context.Background(), ctrlclient.ObjectKey{Name: "test-node"}, p); err != nil {
+		t.Fatalf("re-reading own peer: %v", err)
+	}
+	return p
+}
+
+func TestApplyNATClassificationUnknownKeepsPreviousType(t *testing.T) {
+	a := newReclassifyAgent(t, ownPeer("symmetric", true))
+	a.detectedNATType = "symmetric"
+	a.isSymmetricNAT = true
+	a.portPrediction = &nat.PortPrediction{SamplePorts: []int{1}}
+	a.natClassifyInFlight = true
+
+	a.applyNATClassification(context.Background(), &NATClassification{NATType: nat.NATUnknown, Error: "1 of 2 responded"})
+
+	// Transient unknown must NOT wipe a previously-known classification.
+	if a.detectedNATType != "symmetric" {
+		t.Fatalf("detectedNATType = %q, want symmetric (unchanged on transient unknown)", a.detectedNATType)
+	}
+	if a.portPrediction == nil {
+		t.Fatalf("portPrediction was wiped on transient unknown")
+	}
+	if a.natClassifyInFlight {
+		t.Fatalf("natClassifyInFlight not cleared")
+	}
+}
+
+func TestApplyNATClassificationSymmetricToConeClearsPortPrediction(t *testing.T) {
+	a := newReclassifyAgent(t, ownPeer("symmetric", true)) // CRD starts with symmetric + portPrediction
+	a.detectedNATType = "symmetric"
+	a.isSymmetricNAT = true
+	a.portPrediction = &nat.PortPrediction{SamplePorts: []int{1, 2}}
+
+	a.applyNATClassification(context.Background(), &NATClassification{NATType: nat.NATCone, ServersResponded: 2, ServersTotal: 2})
+
+	// In-memory state updated.
+	if a.detectedNATType != "cone" || a.isSymmetricNAT {
+		t.Fatalf("in-memory = (%q, sym=%v), want (cone, false)", a.detectedNATType, a.isSymmetricNAT)
+	}
+	if a.portPrediction != nil {
+		t.Fatalf("portPrediction = %+v, want nil after symmetric→cone", a.portPrediction)
+	}
+	// CRD status updated AND the stale portPrediction actually cleared.
+	got := readOwnPeer(t, a)
+	if got.Status.NATType != "cone" {
+		t.Fatalf("status.NATType = %q, want cone", got.Status.NATType)
+	}
+	if got.Status.PortPrediction != nil {
+		t.Fatalf("status.PortPrediction = %+v, want nil (merge patch must clear it)", got.Status.PortPrediction)
+	}
+}
+
+func TestApplyNATClassificationConeToSymmetricWritesPortPrediction(t *testing.T) {
+	a := newReclassifyAgent(t, ownPeer("cone", false))
+	a.detectedNATType = "cone"
+
+	a.applyNATClassification(context.Background(), &NATClassification{
+		NATType:          nat.NATSymmetric,
+		PortPrediction:   &nat.PortPrediction{BasePort: 5000, SamplePorts: []int{5000, 5100}},
+		ServersResponded: 2, ServersTotal: 2,
+	})
+
+	if a.detectedNATType != "symmetric" || !a.isSymmetricNAT {
+		t.Fatalf("in-memory = (%q, sym=%v), want (symmetric, true)", a.detectedNATType, a.isSymmetricNAT)
+	}
+	got := readOwnPeer(t, a)
+	if got.Status.NATType != "symmetric" {
+		t.Fatalf("status.NATType = %q, want symmetric", got.Status.NATType)
+	}
+	if got.Status.PortPrediction == nil || len(got.Status.PortPrediction.SamplePorts) != 2 {
+		t.Fatalf("status.PortPrediction = %+v, want 2 sample ports", got.Status.PortPrediction)
+	}
+}
+
+// TestMaybeReclassifyNATAppliesDrainedResult drives the drain+apply path on the
+// sync goroutine without launching the (network-bound) background probe: a
+// completed classification is pre-placed on the channel and the pacing fields
+// are set so no new goroutine is started.
+func TestMaybeReclassifyNATAppliesDrainedResult(t *testing.T) {
+	a := newReclassifyAgent(t, ownPeer("cone", false))
+	a.detectedNATType = "cone"
+	a.reclassifyEvery = time.Hour
+	a.lastNATClassify = time.Now() // recent → no new probe launched
+	a.natClassifyInFlight = true
+	a.natClassCh = make(chan *NATClassification, 1)
+	a.natClassCh <- &NATClassification{
+		NATType:          nat.NATSymmetric,
+		PortPrediction:   &nat.PortPrediction{SamplePorts: []int{7000, 7100}},
+		ServersResponded: 2, ServersTotal: 2,
+	}
+
+	a.maybeReclassifyNAT(context.Background())
+
+	if a.detectedNATType != "symmetric" {
+		t.Fatalf("detectedNATType = %q, want symmetric (drained result applied)", a.detectedNATType)
+	}
+	if a.natClassifyInFlight {
+		t.Fatalf("natClassifyInFlight not cleared after apply")
+	}
+	// Channel should be empty (drained, not refilled — no new probe this tick).
+	select {
+	case <-a.natClassCh:
+		t.Fatalf("channel unexpectedly non-empty (a probe was launched)")
+	default:
+	}
+}

--- a/pkg/agent/nat_reclassify_test.go
+++ b/pkg/agent/nat_reclassify_test.go
@@ -146,6 +146,31 @@ func TestApplyNATClassificationConeToSymmetricWritesPortPrediction(t *testing.T)
 	}
 }
 
+// TestApplyNATClassificationKeepsPortRestrictedConeOnConeResult guards the
+// regression where the STUN-only periodic classifier (which cannot detect port
+// restriction) downgrades a setup-refined port-restricted-cone node to plain
+// cone — which would wrongly un-pin port-restricted↔symmetric pairs from relay.
+func TestApplyNATClassificationKeepsPortRestrictedConeOnConeResult(t *testing.T) {
+	a := newReclassifyAgent(t, ownPeer(string(nat.NATPortRestrictedCone), false))
+	a.detectedNATType = string(nat.NATPortRestrictedCone)
+
+	// A plain "cone" result must NOT downgrade the refinement.
+	a.applyNATClassification(context.Background(), &NATClassification{NATType: nat.NATCone, ServersResponded: 2, ServersTotal: 2})
+	if a.detectedNATType != string(nat.NATPortRestrictedCone) {
+		t.Fatalf("detectedNATType = %q, want port-restricted-cone (cone must not downgrade refinement)", a.detectedNATType)
+	}
+
+	// A genuine change (symmetric) is still applied.
+	a.applyNATClassification(context.Background(), &NATClassification{
+		NATType:          nat.NATSymmetric,
+		PortPrediction:   &nat.PortPrediction{SamplePorts: []int{1, 2}},
+		ServersResponded: 2, ServersTotal: 2,
+	})
+	if a.detectedNATType != "symmetric" {
+		t.Fatalf("detectedNATType = %q, want symmetric (genuine change still applied)", a.detectedNATType)
+	}
+}
+
 // TestMaybeReclassifyNATAppliesDrainedResult drives the drain+apply path on the
 // sync goroutine without launching the (network-bound) background probe: a
 // completed classification is pre-placed on the channel and the pacing fields

--- a/pkg/agent/path_monitor.go
+++ b/pkg/agent/path_monitor.go
@@ -128,6 +128,11 @@ type pathEntry struct {
 	// attack disabled). Cleared via ClearNeverDirect when conditions
 	// change (e.g. NAT type re-discovery).
 	neverDirect bool
+	// probeBackoffUntil temporarily suppresses Relay→Warm probes after the
+	// ICE layer has already proven direct probing unstable. Unlike
+	// neverDirect, this is time-bound and is cleared automatically after the
+	// deadline or explicitly on NAT re-classification.
+	probeBackoffUntil time.Time
 }
 
 // PathMonitorConfig bundles the thresholds. Defaults are applied for any
@@ -245,6 +250,48 @@ func (m *PathMonitor) ClearNeverDirect(peerName string) {
 	}
 }
 
+// BackoffDirectProbeUntil keeps a peer in Relay mode until the given deadline.
+// It is used to mirror ICE's unstable-direct-probe backoff into the transport
+// FSM; without this, PathMonitor would keep moving Relay→Warm on its own timer
+// even while ICE is intentionally holding direct probes back.
+func (m *PathMonitor) BackoffDirectProbeUntil(peerName, pubKey string, until time.Time) {
+	if until.IsZero() {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	e, ok := m.entries[peerName]
+	if !ok {
+		e = &pathEntry{
+			pubKey:        pubKey,
+			mode:          PathModeRelay,
+			modeEnteredAt: now,
+			lastProbeAt:   now,
+		}
+		m.entries[peerName] = e
+	}
+	e.pubKey = pubKey
+	if until.After(e.probeBackoffUntil) {
+		e.probeBackoffUntil = until
+	}
+	e.lastProbeAt = now
+	if e.mode != PathModeRelay {
+		e.setMode(PathModeRelay, now)
+	}
+}
+
+// ClearProbeBackoff clears the temporary direct-probe hold for a peer.
+func (m *PathMonitor) ClearProbeBackoff(peerName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.entries[peerName]; ok {
+		e.probeBackoffUntil = time.Time{}
+	}
+}
+
 // ForgetMissing removes entries for any peers not present in `alive`. Call
 // from the sync loop after listing the current peer set so the monitor's
 // map does not accumulate stale entries across CRD churn.
@@ -353,6 +400,12 @@ func (m *PathMonitor) Evaluate(peerName, pubKey string, forceProbe bool) PathMod
 		// must call ClearNeverDirect to re-enable probing.
 		if e.neverDirect {
 			break
+		}
+		if !forceProbe && !e.probeBackoffUntil.IsZero() {
+			if now.Before(e.probeBackoffUntil) {
+				break
+			}
+			e.probeBackoffUntil = time.Time{}
 		}
 		if forceProbe || now.Sub(e.lastProbeAt) >= m.relayRetry {
 			e.lastProbeAt = now

--- a/pkg/agent/path_monitor_test.go
+++ b/pkg/agent/path_monitor_test.go
@@ -277,3 +277,41 @@ func TestClearNeverDirectRestoresProbing(t *testing.T) {
 		t.Fatalf("Evaluate after ClearNeverDirect = %v, want PathModeWarm", got)
 	}
 }
+
+func TestBackoffDirectProbeUntilSuppressesTimerProbe(t *testing.T) {
+	pm, _, clk := newMonitor(t)
+	pm.Evaluate("p1", "key1", false) // Relay, lastProbeAt = now
+
+	pm.BackoffDirectProbeUntil("p1", "key1", clk.now().Add(time.Second))
+	clk.advance(300 * time.Millisecond) // > relayRetry (200ms)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeRelay {
+		t.Fatalf("Evaluate during probe backoff = %v, want PathModeRelay", got)
+	}
+
+	clk.advance(time.Second)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("Evaluate after probe backoff = %v, want PathModeWarm", got)
+	}
+}
+
+func TestForceProbeOverridesTemporaryBackoff(t *testing.T) {
+	pm, _, clk := newMonitor(t)
+	pm.Evaluate("p1", "key1", false)
+	pm.BackoffDirectProbeUntil("p1", "key1", clk.now().Add(time.Second))
+
+	if got := pm.Evaluate("p1", "key1", true); got != PathModeWarm {
+		t.Fatalf("forced Evaluate during probe backoff = %v, want PathModeWarm", got)
+	}
+}
+
+func TestClearProbeBackoffRestoresTimerProbe(t *testing.T) {
+	pm, _, clk := newMonitor(t)
+	pm.Evaluate("p1", "key1", false)
+	pm.BackoffDirectProbeUntil("p1", "key1", clk.now().Add(time.Second))
+
+	clk.advance(300 * time.Millisecond) // > relayRetry (200ms)
+	pm.ClearProbeBackoff("p1")
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("Evaluate after ClearProbeBackoff = %v, want PathModeWarm", got)
+	}
+}

--- a/pkg/agent/relay/client.go
+++ b/pkg/agent/relay/client.go
@@ -7,12 +7,15 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	relayproto "github.com/wirekube/wirekube/pkg/relay"
 )
+
+var clientDebug = os.Getenv("WIREKUBE_BIND_DEBUG") == "1"
 
 // Client manages a TCP connection to the relay server and routes packets
 // between local UDP proxies and remote peers via the relay.
@@ -381,7 +384,13 @@ func (c *Client) SendToExternal(sourceToken uint64, payload []byte) error {
 	if err := relayproto.WriteFrame(c.writer, frame); err != nil {
 		return err
 	}
-	return c.writer.Flush()
+	if err := c.writer.Flush(); err != nil {
+		return err
+	}
+	if clientDebug {
+		log.Printf("relay-client: external response sent relay=%s token=%d len=%d", c.relayAddr, sourceToken, len(payload))
+	}
+	return nil
 }
 
 // SendBimodalHint asks the relay to deliver a hint to destPubKey telling it

--- a/pkg/agent/route_filter_test.go
+++ b/pkg/agent/route_filter_test.go
@@ -29,19 +29,21 @@ func TestFilterRoutesForConnectedPeersKeepsRelayBootstrapRoutes(t *testing.T) {
 	routes := []string{
 		"198.18.18.1/32",
 		"198.18.18.2/32",
+		"10.0.0.154/32",
 		"198.18.18.3/32",
 		"198.18.18.4/32",
 	}
 	routeOwners := map[string]string{
 		"198.18.18.1/32": connectedKey,
 		"198.18.18.2/32": relayedKey,
+		"10.0.0.154/32":  relayedKey,
 		"198.18.18.3/32": unreadyKey,
 	}
 	allowBeforeHandshake := map[string]bool{
 		relayedKey: true,
 	}
 
-	got := a.filterRoutesForConnectedPeers(routes, routeOwners, allowBeforeHandshake)
+	got := a.filterRoutesForConnectedPeers(routes, routeOwners, allowBeforeHandshake, "198.18.0.0/16")
 	want := []string{
 		"198.18.18.1/32",
 		"198.18.18.2/32",
@@ -49,5 +51,67 @@ func TestFilterRoutesForConnectedPeersKeepsRelayBootstrapRoutes(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("filterRoutesForConnectedPeers() = %v, want %v", got, want)
+	}
+}
+
+func TestFilterRoutesForConnectedPeersDoesNotBootstrapWithoutMeshCIDR(t *testing.T) {
+	relayedKey := "relayed-peer-key"
+
+	a := &Agent{
+		log: logr.Discard(),
+		wgMgr: &fakeWGEngine{
+			stats: []wireguard.PeerStats{{PublicKeyB64: relayedKey}},
+		},
+	}
+
+	routes := []string{"198.18.18.2/32"}
+	routeOwners := map[string]string{"198.18.18.2/32": relayedKey}
+	allowBeforeHandshake := map[string]bool{relayedKey: true}
+
+	got := a.filterRoutesForConnectedPeers(routes, routeOwners, allowBeforeHandshake, "")
+	if len(got) != 0 {
+		t.Fatalf("filterRoutesForConnectedPeers() = %v, want no routes", got)
+	}
+}
+
+func TestFilterRoutesForConnectedPeersBootstrapsExternalMeshHostRoute(t *testing.T) {
+	externalKey := "external-peer-key"
+
+	a := &Agent{
+		log: logr.Discard(),
+		wgMgr: &fakeWGEngine{
+			stats: []wireguard.PeerStats{{PublicKeyB64: externalKey}},
+		},
+	}
+
+	routes := []string{"198.18.18.20/32"}
+	routeOwners := map[string]string{"198.18.18.20/32": externalKey}
+	allowBeforeHandshake := map[string]bool{externalKey: true}
+
+	got := a.filterRoutesForConnectedPeers(routes, routeOwners, allowBeforeHandshake, "198.18.18.0/24")
+	if !reflect.DeepEqual(got, routes) {
+		t.Fatalf("filterRoutesForConnectedPeers() = %v, want %v", got, routes)
+	}
+}
+
+func TestIsMeshHostRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		cidr     string
+		meshCIDR string
+		want     bool
+	}{
+		{name: "mesh host route", cidr: "198.18.18.2/32", meshCIDR: "198.18.0.0/16", want: true},
+		{name: "underlay host route", cidr: "10.0.0.154/32", meshCIDR: "198.18.0.0/16", want: false},
+		{name: "mesh aggregate", cidr: "198.18.18.0/24", meshCIDR: "198.18.0.0/16", want: false},
+		{name: "invalid mesh", cidr: "198.18.18.2/32", meshCIDR: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMeshHostRoute(tt.cidr, tt.meshCIDR); got != tt.want {
+				t.Fatalf("isMeshHostRoute(%q, %q) = %v, want %v", tt.cidr, tt.meshCIDR, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/agent/route_filter_test.go
+++ b/pkg/agent/route_filter_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/wirekube/wirekube/pkg/wireguard"
+)
+
+func TestFilterRoutesForConnectedPeersKeepsRelayBootstrapRoutes(t *testing.T) {
+	connectedKey := "connected-peer-key"
+	relayedKey := "relayed-peer-key"
+	unreadyKey := "unready-peer-key"
+
+	a := &Agent{
+		log: logr.Discard(),
+		wgMgr: &fakeWGEngine{
+			stats: []wireguard.PeerStats{
+				{PublicKeyB64: connectedKey, LastHandshake: time.Now()},
+				{PublicKeyB64: relayedKey},
+				{PublicKeyB64: unreadyKey},
+			},
+		},
+	}
+
+	routes := []string{
+		"198.18.18.1/32",
+		"198.18.18.2/32",
+		"198.18.18.3/32",
+		"198.18.18.4/32",
+	}
+	routeOwners := map[string]string{
+		"198.18.18.1/32": connectedKey,
+		"198.18.18.2/32": relayedKey,
+		"198.18.18.3/32": unreadyKey,
+	}
+	allowBeforeHandshake := map[string]bool{
+		relayedKey: true,
+	}
+
+	got := a.filterRoutesForConnectedPeers(routes, routeOwners, allowBeforeHandshake)
+	want := []string{
+		"198.18.18.1/32",
+		"198.18.18.2/32",
+		"198.18.18.4/32",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterRoutesForConnectedPeers() = %v, want %v", got, want)
+	}
+}

--- a/pkg/relay/external_wg.go
+++ b/pkg/relay/external_wg.go
@@ -195,12 +195,11 @@ func (l *ExternalWGListener) writeToIngress(ingressKey [PubKeySize]byte, token u
 		return fmt.Errorf("ingress peer %x not connected", ingressKey[:8])
 	}
 	frame := MakeExternalDataFrame(token, src.String(), payload)
-	ingress.mu.Lock()
-	defer ingress.mu.Unlock()
-	if err := WriteFrame(ingress.writer, frame); err != nil {
+	if err := ingress.writeFrame(frame); err != nil {
+		l.server.dropPeer(ingress)
 		return err
 	}
-	return ingress.writer.Flush()
+	return nil
 }
 
 func (l *ExternalWGListener) AllowsIngress(ingress [PubKeySize]byte) bool {

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -12,7 +12,26 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/wirekube/wirekube/pkg/relay/portalloc"
+)
+
+// NAT probe rate limiting. Legitimate probing is rare (startup plus periodic
+// re-classification), so a modest global cap keeps the relay from being abused
+// as a UDP reflector while never throttling real traffic. Each allowed probe
+// emits two ~19-byte datagrams, so even at the sustained cap the reflected
+// volume is negligible.
+//
+// The cap is global, not per-peer: it bounds a mesh of up to ~100 agents
+// probing simultaneously at startup. Beyond that, some legitimate probes are
+// dropped and the affected agents fall back to conservative NAT classification
+// until the next re-classification cycle (a slow degradation, not a failure).
+// Per-peer fairness — so one peer cannot starve others — requires trusted peer
+// identity and is deferred to control-plane authentication.
+const (
+	probeRateLimit = 100 // probes per second, sustained
+	probeRateBurst = 100
 )
 
 // Server is a WireKube relay server that forwards WireGuard UDP packets
@@ -34,6 +53,11 @@ type Server struct {
 	// probeSem limits concurrent NAT probe goroutines to prevent unbounded
 	// goroutine creation from rapid probe requests.
 	probeSem chan struct{}
+
+	// probeLimiter caps the sustained NAT-probe rate across all peers so the
+	// relay cannot be driven as a UDP reflector by an unauthenticated flood of
+	// probe frames on the public control port.
+	probeLimiter *rate.Limiter
 
 	// forwarder + alloc handle external-peer traffic. Both may be nil if
 	// the operator opted out of external-peer support; in that case the
@@ -57,8 +81,9 @@ type clientConn struct {
 
 func NewServer() *Server {
 	return &Server{
-		peers:    make(map[[PubKeySize]byte]*clientConn),
-		probeSem: make(chan struct{}, 16),
+		peers:        make(map[[PubKeySize]byte]*clientConn),
+		probeSem:     make(chan struct{}, 16),
+		probeLimiter: rate.NewLimiter(probeRateLimit, probeRateBurst),
 	}
 }
 
@@ -339,6 +364,14 @@ func (s *Server) handleConn(conn net.Conn) {
 				log.Printf("relay: bad NAT probe frame from %x: %v", pubKey[:8], err)
 				continue
 			}
+			if err := validateProbeTarget(ip, port); err != nil {
+				log.Printf("relay: rejecting NAT probe from %x to %s: %v", pubKey[:8], ip, err)
+				continue
+			}
+			if !s.probeLimiter.Allow() {
+				log.Printf("relay: NAT probe rate-limited (from %x to %s)", pubKey[:8], ip)
+				continue
+			}
 			select {
 			case s.probeSem <- struct{}{}:
 				go func() {
@@ -558,6 +591,29 @@ func (s *Server) handleForwarderUnregister(conn net.Conn, frame Frame) {
 	_ = WriteFrame(writer, MakeForwarderUnregisterFrame(port))
 	_ = writer.Flush()
 	log.Printf("relay: forwarder unregistered: port=%d", port)
+}
+
+// validateProbeTarget guards the relay's NAT-probe primitive from being aimed
+// at internal infrastructure. It rejects addresses that can never be a real
+// external NAT endpoint — loopback, link-local (including the cloud metadata
+// range 169.254.169.254), multicast, the unspecified address and the limited
+// broadcast address — so the relay cannot be used to reach a node's own network
+// or a metadata service. Private (RFC1918) and CGNAT (100.64.0.0/10) targets
+// are deliberately ALLOWED: intra-VPC / intra-cluster peers (e.g. EKS/GKE node
+// ranges) legitimately probe such endpoints, so treating them like public
+// targets (rate-limited, not blocked) is consistent. The rate limiter bounds
+// abuse of the allowed paths; per-peer fairness is deferred to control-plane
+// authentication.
+func validateProbeTarget(target net.IP, port int) error {
+	if port <= 0 || port > 65535 {
+		return fmt.Errorf("invalid target port %d", port)
+	}
+	if target == nil || target.IsUnspecified() || target.IsLoopback() ||
+		target.IsLinkLocalUnicast() || target.IsLinkLocalMulticast() ||
+		target.IsMulticast() || target.Equal(net.IPv4bcast) {
+		return fmt.Errorf("non-routable target")
+	}
+	return nil
 }
 
 // sendNATProbe sends two UDP probes to the specified endpoint:

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/netip"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,6 +17,8 @@ import (
 
 	"github.com/wirekube/wirekube/pkg/relay/portalloc"
 )
+
+var relayDebug = os.Getenv("WIREKUBE_RELAY_DEBUG") == "1"
 
 // NAT probe rate limiting. Legitimate probing is rare (startup plus periodic
 // re-classification), so a modest global cap keeps the relay from being abused
@@ -79,6 +82,39 @@ type clientConn struct {
 	probes  map[uint64]chan struct{}
 }
 
+var relayClientWriteTimeout = 2 * time.Second
+
+func (c *clientConn) writeFrame(frame Frame) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if relayClientWriteTimeout > 0 {
+		if err := c.conn.SetWriteDeadline(time.Now().Add(relayClientWriteTimeout)); err != nil {
+			return err
+		}
+	}
+	err := WriteFrame(c.writer, frame)
+	if err == nil {
+		err = c.writer.Flush()
+	}
+	if relayClientWriteTimeout > 0 {
+		_ = c.conn.SetWriteDeadline(time.Time{})
+	}
+	if err != nil {
+		_ = c.conn.Close()
+	}
+	return err
+}
+
+func (s *Server) dropPeer(c *clientConn) {
+	_ = c.conn.Close()
+	s.mu.Lock()
+	if s.peers[c.pubKey] == c {
+		delete(s.peers, c.pubKey)
+	}
+	s.mu.Unlock()
+}
+
 func NewServer() *Server {
 	return &Server{
 		peers:        make(map[[PubKeySize]byte]*clientConn),
@@ -120,12 +156,11 @@ func (s *Server) Dispatch(ingress, external [PubKeySize]byte, payload []byte, _ 
 		return fmt.Errorf("ingress %x not connected", ingress[:8])
 	}
 	out := MakeDataFrame(external, payload)
-	dest.mu.Lock()
-	defer dest.mu.Unlock()
-	if err := WriteFrame(dest.writer, out); err != nil {
+	if err := dest.writeFrame(out); err != nil {
+		s.dropPeer(dest)
 		return err
 	}
-	return dest.writer.Flush()
+	return nil
 }
 
 func (s *Server) ListenAndServe(addr string) error {
@@ -298,15 +333,9 @@ func (s *Server) handleConn(conn net.Conn) {
 			}
 
 			outFrame := MakeDataFrame(pubKey, payload)
-			dest.mu.Lock()
-			err = WriteFrame(dest.writer, outFrame)
-			if err == nil {
-				err = dest.writer.Flush()
-			}
-			dest.mu.Unlock()
-
-			if err != nil {
+			if err := dest.writeFrame(outFrame); err != nil {
 				log.Printf("relay: forward error to %x: %v", destKey[:8], err)
+				s.dropPeer(dest)
 			}
 			// Successful forwards intentionally not logged: a busy relay
 			// (RelayModeAlways / warm-bimodal) can push tens of frames per
@@ -331,6 +360,8 @@ func (s *Server) handleConn(conn net.Conn) {
 			s.externalWG.BindTokenIngress(token, pubKey)
 			if err := s.externalWG.SendToExternal(token, payload); err != nil {
 				log.Printf("relay: external data response from %x token=%d failed: %v", pubKey[:8], token, err)
+			} else if relayDebug {
+				log.Printf("relay: external data response from %x token=%d len=%d sent", pubKey[:8], token, len(payload))
 			}
 
 		case MsgBimodalHint:
@@ -348,14 +379,9 @@ func (s *Server) handleConn(conn net.Conn) {
 			// Forward with sender pubkey so the destination can key the hint
 			// by peer; body carries the sender (not the dest) on the wire.
 			outFrame := Frame{Type: MsgBimodalHint, Body: pubKey[:]}
-			dest.mu.Lock()
-			err = WriteFrame(dest.writer, outFrame)
-			if err == nil {
-				err = dest.writer.Flush()
-			}
-			dest.mu.Unlock()
-			if err != nil {
+			if err := dest.writeFrame(outFrame); err != nil {
 				log.Printf("relay: forward bimodal hint to %x: %v", destKey[:8], err)
+				s.dropPeer(dest)
 			}
 
 		case MsgNATProbe:
@@ -477,13 +503,7 @@ func (c *clientConn) probe(ctx context.Context, token uint64, timeout time.Durat
 	}()
 
 	start := time.Now()
-	c.mu.Lock()
-	err := WriteFrame(c.writer, MakeRelayProbeFrame(token))
-	if err == nil {
-		err = c.writer.Flush()
-	}
-	c.mu.Unlock()
-	if err != nil {
+	if err := c.writeFrame(MakeRelayProbeFrame(token)); err != nil {
 		return 0, err
 	}
 

--- a/pkg/relay/server_test.go
+++ b/pkg/relay/server_test.go
@@ -338,3 +338,51 @@ func freeUDPPort(t *testing.T) uint16 {
 	defer conn.Close()
 	return uint16(conn.LocalAddr().(*net.UDPAddr).Port)
 }
+
+func TestValidateProbeTarget(t *testing.T) {
+	cases := []struct {
+		name    string
+		target  net.IP
+		port    int
+		wantErr bool
+	}{
+		{"public global-unicast", net.IPv4(203, 0, 113, 7), 3478, false},
+		{"private RFC1918 (intra-VPC)", net.IPv4(10, 1, 2, 3), 3478, false},
+		// Deliberately allowed: CGNAT addresses real intra-cluster node ranges
+		// (EKS/GKE), same rationale as RFC1918. Pinned so a future tightening
+		// cannot silently regress the intra-cluster path.
+		{"CGNAT 100.64/10 (intra-cluster)", net.IPv4(100, 64, 1, 1), 3478, false},
+		{"cloud metadata link-local", net.IPv4(169, 254, 169, 254), 3478, true},
+		{"loopback", net.IPv4(127, 0, 0, 1), 3478, true},
+		{"unspecified", net.IPv4zero, 3478, true},
+		{"multicast", net.IPv4(224, 0, 0, 1), 3478, true},
+		{"limited broadcast", net.IPv4bcast, 3478, true},
+		{"nil", nil, 3478, true},
+		{"zero port", net.IPv4(203, 0, 113, 7), 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateProbeTarget(tc.target, tc.port); tc.wantErr != (err != nil) {
+				t.Fatalf("validateProbeTarget(%v, %d) err = %v, wantErr = %v", tc.target, tc.port, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestProbeLimiterBoundsRate(t *testing.T) {
+	s := NewServer()
+	// Drain the burst, then confirm the limiter starts denying — proving the
+	// relay cannot be driven as an unbounded UDP reflector.
+	allowed := 0
+	for range probeRateBurst + 50 {
+		if s.probeLimiter.Allow() {
+			allowed++
+		}
+	}
+	if allowed > probeRateBurst {
+		t.Fatalf("allowed %d probes, want <= burst %d", allowed, probeRateBurst)
+	}
+	if s.probeLimiter.Allow() {
+		t.Fatal("limiter still allowing after burst exhausted")
+	}
+}

--- a/pkg/relay/server_test.go
+++ b/pkg/relay/server_test.go
@@ -1,11 +1,36 @@
 package relay
 
 import (
+	"bufio"
 	"net"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestClientConnWriteFrameTimesOut(t *testing.T) {
+	oldTimeout := relayClientWriteTimeout
+	relayClientWriteTimeout = 20 * time.Millisecond
+	defer func() { relayClientWriteTimeout = oldTimeout }()
+
+	serverSide, clientSide := net.Pipe()
+	defer clientSide.Close()
+
+	cc := &clientConn{
+		pubKey: pubkey(1),
+		conn:   serverSide,
+		writer: bufio.NewWriter(serverSide),
+	}
+
+	start := time.Now()
+	err := cc.writeFrame(MakeKeepaliveFrame())
+	if err == nil {
+		t.Fatal("writeFrame succeeded; want timeout")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("writeFrame blocked for %s; want bounded timeout", elapsed)
+	}
+}
 
 func TestServer_ExplicitForwarderRegisterReservesPort(t *testing.T) {
 	port := freeUDPPort(t)

--- a/pkg/wireguard/bind.go
+++ b/pkg/wireguard/bind.go
@@ -364,6 +364,10 @@ func (b *WireKubeBind) Send(bufs [][]byte, ep conn.Endpoint) error {
 			return syscall.ENOTCONN
 		}
 		for _, buf := range bufs {
+			if bindDebug {
+				log.Printf("[bind] external send relay=%s token=%d len=%d",
+					wkep.externalSource.RelayAddr, wkep.externalSource.Token, len(buf))
+			}
 			if err := relay.SendToExternal(wkep.externalSource.RelayAddr, wkep.externalSource.Token, buf); err != nil {
 				return err
 			}
@@ -675,6 +679,10 @@ func (b *WireKubeBind) makeRelayReceiveFunc() conn.ReceiveFunc {
 				eps[0] = &WireKubeEndpoint{
 					dst:            dst,
 					externalSource: pkt.ExternalSource,
+				}
+				if bindDebug {
+					log.Printf("[bind] external receive relay=%s token=%d source=%s len=%d",
+						pkt.ExternalSource.RelayAddr, pkt.ExternalSource.Token, pkt.ExternalSource.Addr, n)
 				}
 				return 1, nil
 			}

--- a/pkg/wireguard/engine.go
+++ b/pkg/wireguard/engine.go
@@ -47,6 +47,12 @@ type WGEngine interface {
 	AddRoute(dst string) error
 	DelRoute(dst string) error
 
+	// EnsureRoutingRules (re)asserts the fwmark and WireKube-table ip rules
+	// that activate the WireKube routing table. Idempotent and safe to call on
+	// every sync tick so the rules self-heal if another component (e.g. Cilium)
+	// flushes them; the routes in the WK table are inert without these rules.
+	EnsureRoutingRules() error
+
 	// Path control for ICE negotiation.
 	// SetPeerPath updates the Bind's pathTable atomically so the next Send()
 	// for this peer uses the requested transport mode.

--- a/pkg/wireguard/routes.go
+++ b/pkg/wireguard/routes.go
@@ -3,6 +3,7 @@
 package wireguard
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -62,18 +63,48 @@ func EnsureRoutingRules() error {
 	// destinations not reachable through WireGuard tunnels.
 	wgRule.SuppressPrefixlen = 0
 
-	// Always remove and re-add the WK rule to ensure SuppressPrefixlen is
-	// applied. A stale rule without suppress (from a previous agent run or
-	// a failed setup attempt) would trap non-WG traffic and break API access.
-	staleWG := netlink.NewRule()
-	staleWG.Table = WKRouteTable
-	staleWG.Priority = 200
-	_ = netlink.RuleDel(staleWG) // ignore error if rule doesn't exist
-
-	if err := netlink.RuleAdd(wgRule); err != nil {
-		return fmt.Errorf("adding wg table rule: %w", err)
+	// Reassert the WK rule idempotently. EnsureRoutingRules runs on every sync
+	// tick (not only at startup) so the rule self-heals if a co-resident
+	// component — notably Cilium's ip-rule reconciliation — flushes it. When a
+	// healthy exact catch-all rule is already present we leave it untouched, so
+	// the steady-state tick performs no Del/Add and never opens a window where
+	// traffic falls through to the main table. Only when the rule is missing or
+	// stale/selector-limited (e.g. an old rule without SuppressPrefixlen, which
+	// would trap non-WG traffic and break API access) do we delete and re-add it.
+	if err := ensureWGTableRule(wgRule); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func ensureWGTableRule(wgRule *netlink.Rule) error {
+	rules, err := netlink.RuleList(syscall.AF_INET)
+	if err != nil {
+		return fmt.Errorf("listing wg table rules: %w", err)
+	}
+
+	healthy, toDelete := wgTableRulePlan(rules)
+	if healthy {
+		return nil
+	}
+
+	for _, r := range toDelete {
+		rule := r
+		if err := netlink.RuleDel(&rule); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("deleting stale wg table rule: %w", err)
+		}
+	}
+
+	if err := netlink.RuleAdd(wgRule); err != nil {
+		if isNetlinkFileExists(err) {
+			rules, listErr := netlink.RuleList(syscall.AF_INET)
+			if listErr == nil && wgRuleHealthyIn(rules) {
+				return nil
+			}
+		}
+		return fmt.Errorf("adding wg table rule: %w", err)
+	}
 	return nil
 }
 
@@ -141,10 +172,11 @@ func SyncRoutesForLink(linkIndex int, preferredSrc net.IP, desired []string) err
 // that the route already exists. netlink returns a sentinel string rather
 // than a typed error, so a string compare is the interface we have.
 func isRouteExists(err error) bool {
-	if err == nil {
-		return false
-	}
-	return err.Error() == "file exists"
+	return isNetlinkFileExists(err)
+}
+
+func isNetlinkFileExists(err error) bool {
+	return err != nil && err.Error() == "file exists"
 }
 
 // AddRouteForLink adds a route for dst through the given link in the WireKube
@@ -204,6 +236,63 @@ func fwmarkRulePriority() int {
 		prio = 199
 	}
 	return prio
+}
+
+// wgRuleHealthyIn is the pure predicate behind ensureWGTableRule. The WK table
+// rule must be an exact catch-all table lookup rule; any rule at the same
+// table/priority that carries selectors or stale attributes is unhealthy and
+// must be recreated.
+func wgRuleHealthyIn(rules []netlink.Rule) bool {
+	found := 0
+	for _, r := range rules {
+		if r.Table != WKRouteTable || r.Priority != 200 {
+			continue
+		}
+		if !wgRuleExactCatchAll(r) {
+			return false
+		}
+		found++
+	}
+	return found == 1
+}
+
+func wgRuleExactCatchAll(r netlink.Rule) bool {
+	return r.Table == WKRouteTable &&
+		r.Priority == 200 &&
+		r.SuppressPrefixlen == 0 &&
+		r.Mark == 0 &&
+		r.Mask == nil &&
+		r.Tos == 0 &&
+		r.TunID == 0 &&
+		r.Goto < 0 &&
+		r.Src == nil &&
+		r.Dst == nil &&
+		r.Flow < 0 &&
+		r.IifName == "" &&
+		r.OifName == "" &&
+		r.SuppressIfgroup < 0 &&
+		!r.Invert &&
+		r.Dport == nil &&
+		r.Sport == nil &&
+		r.IPProto == 0 &&
+		r.UIDRange == nil
+}
+
+func wgTableRulePlan(rules []netlink.Rule) (bool, []netlink.Rule) {
+	if wgRuleHealthyIn(rules) {
+		return true, nil
+	}
+	return false, wgTablePriorityRules(rules)
+}
+
+func wgTablePriorityRules(rules []netlink.Rule) []netlink.Rule {
+	out := make([]netlink.Rule, 0)
+	for _, r := range rules {
+		if r.Table == WKRouteTable && r.Priority == 200 {
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // ruleExists checks if a matching ip rule already exists.

--- a/pkg/wireguard/routes_test.go
+++ b/pkg/wireguard/routes_test.go
@@ -1,0 +1,203 @@
+//go:build linux
+
+package wireguard
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestWgRuleHealthyIn(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []netlink.Rule
+		want  bool
+	}{
+		{
+			name:  "healthy: table+priority+suppress0",
+			rules: []netlink.Rule{wkRule()},
+			want:  true,
+		},
+		{
+			name:  "unhealthy: rule without suppress (sentinel -1)",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.SuppressPrefixlen = -1 })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: wrong priority",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.Priority = 100 })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: wrong table",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.Table = 254 })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: empty",
+			rules: nil,
+			want:  false,
+		},
+		{
+			name: "healthy among unrelated rules",
+			rules: []netlink.Rule{
+				{Table: 255, Priority: 100, SuppressPrefixlen: -1},
+				wkRule(),
+				{Table: 254, Priority: 32766, SuppressPrefixlen: -1},
+			},
+			want: true,
+		},
+		{
+			name: "unhealthy: stale duplicate with healthy rule",
+			rules: []netlink.Rule{
+				wkRule(),
+				wkRule(func(r *netlink.Rule) { r.SuppressPrefixlen = -1 }),
+			},
+			want: false,
+		},
+		{
+			name: "unhealthy: duplicate exact rules",
+			rules: []netlink.Rule{
+				wkRule(),
+				wkRule(),
+			},
+			want: false,
+		},
+		{
+			name:  "unhealthy: selector-limited mark rule",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.Mark = WKFwMark })},
+			want:  false,
+		},
+		{
+			name: "unhealthy: selector-limited source rule",
+			rules: []netlink.Rule{
+				wkRule(func(r *netlink.Rule) {
+					r.Src = mustCIDR(t, "10.0.0.0/24")
+				}),
+			},
+			want: false,
+		},
+		{
+			name:  "unhealthy: selector-limited input interface rule",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.IifName = "eth0" })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: inverted rule",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.Invert = true })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: selector-limited port rule",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.Dport = netlink.NewRulePortRange(51820, 51820) })},
+			want:  false,
+		},
+		{
+			name:  "unhealthy: selector-limited uid rule",
+			rules: []netlink.Rule{wkRule(func(r *netlink.Rule) { r.UIDRange = netlink.NewRuleUIDRange(1000, 1000) })},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wgRuleHealthyIn(tt.rules); got != tt.want {
+				t.Errorf("wgRuleHealthyIn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWgTableRulePlan(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       []netlink.Rule
+		wantHealthy bool
+		wantDelete  int
+	}{
+		{
+			name:        "healthy exact rule needs no delete",
+			rules:       []netlink.Rule{wkRule()},
+			wantHealthy: true,
+			wantDelete:  0,
+		},
+		{
+			name:        "missing rule adds without delete",
+			rules:       []netlink.Rule{{Table: 254, Priority: 200, SuppressPrefixlen: -1}},
+			wantHealthy: false,
+			wantDelete:  0,
+		},
+		{
+			name:        "stale rule is deleted before add",
+			rules:       []netlink.Rule{wkRule(func(r *netlink.Rule) { r.SuppressPrefixlen = -1 })},
+			wantHealthy: false,
+			wantDelete:  1,
+		},
+		{
+			name: "healthy and stale duplicate are both replaced",
+			rules: []netlink.Rule{
+				wkRule(),
+				wkRule(func(r *netlink.Rule) { r.SuppressPrefixlen = -1 }),
+			},
+			wantHealthy: false,
+			wantDelete:  2,
+		},
+		{
+			name: "duplicate exact rules are replaced",
+			rules: []netlink.Rule{
+				wkRule(),
+				wkRule(),
+			},
+			wantHealthy: false,
+			wantDelete:  2,
+		},
+		{
+			name: "selector-limited rule is deleted but unrelated rules are ignored",
+			rules: []netlink.Rule{
+				{Table: 255, Priority: 100, SuppressPrefixlen: -1},
+				wkRule(func(r *netlink.Rule) { r.IifName = "eth0" }),
+				{Table: 254, Priority: 32766, SuppressPrefixlen: -1},
+			},
+			wantHealthy: false,
+			wantDelete:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHealthy, gotDelete := wgTableRulePlan(tt.rules)
+			if gotHealthy != tt.wantHealthy {
+				t.Fatalf("wgTableRulePlan() healthy = %v, want %v", gotHealthy, tt.wantHealthy)
+			}
+			if len(gotDelete) != tt.wantDelete {
+				t.Fatalf("wgTableRulePlan() delete len = %d, want %d", len(gotDelete), tt.wantDelete)
+			}
+			for _, r := range gotDelete {
+				if r.Table != WKRouteTable || r.Priority != 200 {
+					t.Fatalf("delete candidate = table %d priority %d, want table %d priority 200", r.Table, r.Priority, WKRouteTable)
+				}
+			}
+		})
+	}
+}
+
+func wkRule(mods ...func(*netlink.Rule)) netlink.Rule {
+	r := netlink.NewRule()
+	r.Table = WKRouteTable
+	r.Priority = 200
+	r.SuppressPrefixlen = 0
+	for _, mod := range mods {
+		mod(r)
+	}
+	return *r
+}
+
+func mustCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse cidr %q: %v", cidr, err)
+	}
+	return ipNet
+}

--- a/pkg/wireguard/userspace_engine.go
+++ b/pkg/wireguard/userspace_engine.go
@@ -379,6 +379,13 @@ func (u *UserspaceEngine) SyncRoutes(desired []string) error {
 	return SyncRoutesForLink(u.linkIndex, u.preferredSrc, desired)
 }
 
+// EnsureRoutingRules delegates to the package-level idempotent implementation.
+// Called both at startup (via Configure) and on every sync tick so the ip
+// rules self-heal if a co-resident component flushes them.
+func (u *UserspaceEngine) EnsureRoutingRules() error {
+	return EnsureRoutingRules()
+}
+
 // AddRoute delegates to the shared AddRouteForLink.
 func (u *UserspaceEngine) AddRoute(dst string) error {
 	return AddRouteForLink(u.linkIndex, u.preferredSrc, dst)

--- a/pkg/wireguard/userspace_engine_unsupported.go
+++ b/pkg/wireguard/userspace_engine_unsupported.go
@@ -75,6 +75,10 @@ func (u *UserspaceEngine) SyncRoutes(_ []string) error {
 	return errUserspaceEngineUnsupported
 }
 
+func (u *UserspaceEngine) EnsureRoutingRules() error {
+	return errUserspaceEngineUnsupported
+}
+
 func (u *UserspaceEngine) AddRoute(_ string) error {
 	return errUserspaceEngineUnsupported
 }


### PR DESCRIPTION
## Summary

Agent NAT/ICE self-heal, relay hardening, admin-web auth, and — most importantly — a fix for a production routing incident.

### Production incident fix (headline)
- **`fix(agent)`: restrict route-before-handshake to mesh-CIDR `/32` host routes.** Pre-handshake route installation for relay-capable peers was installing the peer's entire AllowedIPs set — including node underlay IPs (`10/8`, `172.16/12`, `192.168/16`), gateway aggregate CIDRs, and pod/service CIDRs. Since the WireKube ip rule (WK table) sits above `main` in priority, those underlay destinations were hijacked into `wire_kube` before any handshake, blackholing node-to-node traffic and taking down CNI/storage paths (ext4 read-only, workload I/O errors). Now gated through `isMeshHostRoute()`: only `/32` routes inside `spec.meshCIDR` install pre-handshake; everything else waits for the handshake.

### Relay
- Harden `NATProbe` against SSRF/reflection (reject non-routable targets, global rate limit).
- Per-write deadline + drop unresponsive clients to avoid head-of-line blocking.
- Loopback `exec nc -z 127.0.0.1 3478` probe so hostNetwork relays aren't failed by a socket-LB CNI intercepting node-IP:3478 connects.

### Agent (concurrency + NAT/ICE)
- Eliminate crash-class data race on agent maps (background goroutines now hand results back to the sync goroutine).
- NAT re-classification / probe-backoff self-heal series; self-heal ip rules every sync tick.

### Admin-web
- Optional HTTP Basic Auth (Secret-injected); refuse non-loopback bind when auth is disabled.

### Chore
- Remove dead `gopapertrail` replace directive.

## Testing
- `go build ./...`, `go vet`, and `go test -race` (excluding `test/e2e` envtest) all green.

## Operational note
- After deploy, verify no underlay/gateway CIDRs land in the WK routing table on any node:
  `kubectl -n wirekube-system exec <agent-pod> -- ip route show table <wk-table>`
