### PR TITLE
feat(relay): add authenticated WSS transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/agent/
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/relay/
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/relay-ws/
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /dev/null ./cmd/wirekubectl/
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/agent/
 
@@ -102,6 +103,9 @@ jobs:
           - cilium-no-kube-proxy
           - flannel
           - calico
+        relay-transport:
+          - tcp
+          - wss
         include:
           - cni-mode: cilium-kube-proxy
             need-helm: true
@@ -111,7 +115,7 @@ jobs:
             need-helm: false
           - cni-mode: calico
             need-helm: false
-    name: e2e (${{ matrix.cni-mode }})
+    name: e2e (${{ matrix.cni-mode }}, ${{ matrix.relay-transport }})
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -146,4 +150,5 @@ jobs:
         run: |
           WIREKUBE_IMAGE=inerplat/wirekube:ci-${{ github.sha }} \
           WIREKUBE_E2E_CNI_MODE=${{ matrix.cni-mode }} \
+          WIREKUBE_E2E_RELAY_TRANSPORT=${{ matrix.relay-transport }} \
           go test -tags kind_e2e -v ./test/kind_e2e/... -timeout 20m

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags="-s -w" -o /out/wirekube-relay ./cmd/relay/
 
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-s -w" -o /out/wirekube-relay-ws ./cmd/relay-ws/
+
 # wirekubectl is baked into the same image so cluster admins can run
 # `kubectl exec deploy/wirekube-agent -- wirekubectl invite alice`
 # without installing any host-side binary. The CLI talks to the
@@ -27,6 +30,7 @@ FROM alpine:3.21
 RUN apk add --no-cache wireguard-tools iptables ip6tables iproute2
 COPY --from=builder /out/wirekube-agent /usr/local/bin/wirekube-agent
 COPY --from=builder /out/wirekube-relay /usr/local/bin/wirekube-relay
+COPY --from=builder /out/wirekube-relay-ws /usr/local/bin/wirekube-relay-ws
 COPY --from=builder /out/wirekubectl /usr/local/bin/wirekubectl
 COPY --from=builder /out/wirekube-admin-web /usr/local/bin/wirekube-admin-web
 ENTRYPOINT ["wirekube-agent"]

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,11 @@ test:
 #   WIREKUBE_E2E_CNI_MODE=cilium-no-kube-proxy   # Cilium kube-proxy replacement + vxlan
 .PHONY: kind-e2e
 kind-e2e:
-	$(GO) test -tags kind_e2e -v ./test/kind_e2e/... -timeout 30m
+	WIREKUBE_E2E_RELAY_TRANSPORT=tcp $(GO) test -tags kind_e2e -v ./test/kind_e2e/... -timeout 30m
+
+.PHONY: kind-e2e-wss
+kind-e2e-wss:
+	WIREKUBE_E2E_RELAY_TRANSPORT=wss $(GO) test -tags kind_e2e -v ./test/kind_e2e/... -timeout 30m
 
 .PHONY: kind-e2e-flannel
 kind-e2e-flannel:
@@ -176,6 +180,7 @@ help:
 	@echo "  init-mesh          Create default WireKubeMesh"
 	@echo "  test               Run unit tests"
 	@echo "  kind-e2e           Run kind-based e2e tests (Cilium CNI, no kind CLI needed)"
+	@echo "  kind-e2e-wss       Run kind-based e2e tests through the WSS relay gateway"
 	@echo "  kind-e2e-flannel   Run kind-based e2e tests with Flannel CNI"
 	@echo "  kind-e2e-calico    Run kind-based e2e tests with Calico CNI"
 	@echo "  kind-e2e-all       Run e2e in all CNI modes (Cilium + Flannel + Calico)"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Connect Kubernetes nodes across any network — no VPN server required.**
 
-WireKube builds a WireGuard mesh between your Kubernetes nodes using only CRDs for coordination. It automatically handles NAT traversal, falls back to TCP relay when direct P2P isn't possible, and preserves WireGuard's end-to-end encryption throughout.
+WireKube builds a WireGuard mesh between your Kubernetes nodes using CRDs for coordination. It keeps a relay path available when configured, probes direct connectivity, and preserves WireGuard payload encryption across both paths.
 
 **[Documentation](https://inerplat.github.io/wirekube/)**
 
@@ -47,10 +47,12 @@ No coordination server, no external etcd, no control plane beyond the Kubernetes
 ```bash
 # 1. Install CRDs and create default mesh configuration
 kubectl apply -f config/crd/
-kubectl apply -f config/wirekubemesh-default.yaml
+kubectl apply -f config/examples/wirekubemesh-basic.yaml
 
-# 2. Deploy the agent DaemonSet
-kubectl apply -f config/agent/
+# 2. Create the namespace, RBAC, and agent DaemonSet
+kubectl create namespace wirekube-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f config/agent/rbac.yaml
+kubectl apply -f config/agent/daemonset.yaml
 
 # 3. Verify
 kubectl get wirekubepeers -o wide
@@ -87,9 +89,9 @@ See the [Quick Start guide](https://inerplat.github.io/wirekube/getting-started/
 | **Bimodal warm-relay datapath** | Direct + relay legs duplicated when the direct path is unproven; WireGuard replay window dedupes. Blackouts are bounded by a 3s trust window, not control-plane sync |
 | **Disco-style failover hints** | On stale receive, a `BimodalHint` is relayed to the peer so asymmetric UDP blackholes recover within one trust window instead of ~30s |
 | **NAT type detection** | `open` / `cone` / `port-restricted-cone` / `symmetric` — public-IP-on-NIC hosts skip traversal entirely |
-| **Automatic NAT traversal** | STUN discovery → direct P2P → TCP relay fallback, fully automatic |
+| **Automatic NAT traversal** | STUN discovery + relay-first availability + direct-path promotion |
 | **Virtual Gateway** | Cross-VPC routing with HA failover via `WireKubeGateway` CRD |
-| **CNI compatible** | Routes only node IPs (`/32`); never touches pod CIDRs |
+| **CNI aware** | Uses an isolated routing table; operators must keep mesh and gateway AllowedIPs from conflicting with CNI routes |
 | **Relay pool scaling** | DNS-based multi-instance relay discovery with automatic failover |
 | **Prometheus metrics** | Peer latency, traffic, connection state, transport mode on `:9090/metrics` |
 
@@ -98,9 +100,9 @@ See the [Quick Start guide](https://inerplat.github.io/wirekube/getting-started/
 | Component | Runs as | Purpose |
 |-----------|---------|---------|
 | **Agent** | DaemonSet (`hostNetwork: true`) | Manages WireGuard interface, discovers endpoints, syncs peers, handles relay failover |
-| **Operator** | Deployment | Reconciles `WireKubeMesh` and `WireKubePeer` CRDs, manages defaults |
 | **Relay** | Deployment + Service | Bridges WireGuard UDP over TCP when NAT blocks direct P2P |
 | **wirekubectl** | CLI | Status inspection and peer management |
+| **Admin web** | Relay sidecar | Manages external peers through the Kubernetes API |
 
 For details on NAT traversal, routing design, and the relay protocol, see the [Architecture documentation](https://inerplat.github.io/wirekube/architecture/overview/).
 
@@ -113,7 +115,7 @@ For details on NAT traversal, routing design, and the relay protocol, see the [A
 | **Fully open-source** | Yes | Client only | Yes | Yes |
 | **CNI dependency** | None (works with any CNI) | None | Requires specific CNI | Requires Cilium |
 | **Scope** | K8s node-to-node mesh | All devices, any OS | K8s multi-cluster | K8s multi-cluster |
-| **External infra** | None required | Tailscale account | Broker cluster | Shared etcd |
+| **External infra** | Kubernetes API; relay required for paths without direct reachability | Tailscale account | Broker cluster | Shared etcd |
 
 **WireKube** is a good fit when you want a lightweight, Kubernetes-native node mesh without external dependencies. **Tailscale** is better if you need to connect non-Kubernetes devices or want a managed service. **Submariner** and **Cilium ClusterMesh** are designed for full multi-cluster service discovery, which is a broader scope than WireKube's node-level connectivity.
 

--- a/cmd/relay-ws/main.go
+++ b/cmd/relay-ws/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	"github.com/wirekube/wirekube/pkg/relay/wsgateway"
+)
+
+func main() {
+	addr := flag.String("addr", ":8081", "HTTP listen address")
+	backendAddr := flag.String("backend-addr", "127.0.0.1:3478", "raw TCP relay backend")
+	path := flag.String("path", "/relay", "WebSocket endpoint path")
+	tlsCertFile := flag.String("tls-cert-file", "", "TLS certificate file")
+	tlsPrivateKeyFile := flag.String("tls-private-key-file", "", "TLS private key file")
+	audience := flag.String("audience", "wirekube-relay", "required ServiceAccount token audience")
+	agentServiceAccount := flag.String("agent-service-account", "wirekube-system/wirekube-agent", "allowed Pod-bound agent ServiceAccount")
+	peerServiceAccountPrefix := flag.String("peer-service-account-prefix", "wirekube-relay-peer-", "prefix for dedicated kubectl-issued per-peer ServiceAccounts")
+	flag.Parse()
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("in-cluster config: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("Kubernetes clientset: %v", err)
+	}
+	scheme := clientgoscheme.Scheme
+	if err := wirekubev1alpha1.AddToScheme(scheme); err != nil {
+		log.Fatalf("WireKube scheme: %v", err)
+	}
+	kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		log.Fatalf("Kubernetes client: %v", err)
+	}
+
+	authenticator := &wsgateway.Authenticator{
+		TokenReviews:             clientset,
+		Client:                   kubeClient,
+		Audience:                 *audience,
+		AgentServiceAccount:      *agentServiceAccount,
+		PeerServiceAccountPrefix: *peerServiceAccountPrefix,
+	}
+	server := wsgateway.NewServer(authenticator, *backendAddr, *path)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	log.Printf("wirekube-relay-ws listening on %s%s, backend %s", *addr, *path, *backendAddr)
+	if err := wsgateway.ListenAndServe(ctx, *addr, server.Handler(), *tlsCertFile, *tlsPrivateKeyFile); err != nil {
+		log.Fatalf("fatal: %v", err)
+	}
+}

--- a/config/crd/wirekube.io_wirekubemeshes.yaml
+++ b/config/crd/wirekube.io_wirekubemeshes.yaml
@@ -195,8 +195,9 @@ spec:
                         type: object
                       controlEndpoint:
                         description: |-
-                          ControlEndpoint is reserved for legacy relay control operations. Shared
-                          external peers use Endpoint directly and do not require this field.
+                          ControlEndpoint is the agent-facing relay endpoint. It is required for
+                          ws/wss transport and may hold a separate raw TCP address for tcp transport.
+                          External WireGuard peers continue to use Endpoint.
                         type: string
                       endpoint:
                         description: |-
@@ -205,11 +206,13 @@ spec:
                         type: string
                       transport:
                         default: tcp
-                        description: Transport is the protocol used to connect to
-                          the relay.
+                        description: |-
+                          Transport selects the single protocol agents use to connect to the relay.
+                          Agents do not open tcp and WebSocket sessions at the same time.
                         enum:
                         - tcp
                         - ws
+                        - wss
                         type: string
                     required:
                     - endpoint

--- a/config/examples/relay-nodeport/service.yaml
+++ b/config/examples/relay-nodeport/service.yaml
@@ -1,0 +1,30 @@
+---
+# Optional relay entry point for clusters where a public LoadBalancer Service is unavailable.
+# Apply after config/relay/deployment.yaml; this changes the same wirekube-relay Service from LoadBalancer to NodePort.
+#
+# Agents outside the cluster connect to <PUBLIC_NODE_IP>:30478.
+# Open TCP 30478 for WireKube agents and UDP 30478 only when external WireGuard peers use the shared relay listener.
+apiVersion: v1
+kind: Service
+metadata:
+  name: wirekube-relay
+  namespace: wirekube-system
+  labels:
+    app.kubernetes.io/name: wirekube-relay
+    app.kubernetes.io/component: relay
+    app.kubernetes.io/part-of: wirekube
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: wirekube-relay
+  ports:
+    - name: relay-tcp
+      port: 3478
+      targetPort: 3478
+      nodePort: 30478
+      protocol: TCP
+    - name: relay-udp
+      port: 3478
+      targetPort: 3478
+      nodePort: 30478
+      protocol: UDP

--- a/config/examples/relay-nodeport/wirekubemesh-external.yaml
+++ b/config/examples/relay-nodeport/wirekubemesh-external.yaml
@@ -1,0 +1,22 @@
+---
+# Use this shape when an agent cannot use the managed relay's cluster-local control Service.
+# Replace the endpoint with a reachable cluster node address.
+apiVersion: wirekube.io/v1alpha1
+kind: WireKubeMesh
+metadata:
+  name: default
+spec:
+  listenPort: 51820
+  interfaceName: wire_kube
+  mtu: 1420
+  stunServers:
+    - stun.cloudflare.com:3478
+    - stun.l.google.com:19302
+  relay:
+    mode: auto
+    provider: external
+    external:
+      endpoint: "REPLACE_WITH_PUBLIC_NODE_IP:30478"
+      transport: tcp
+    handshakeTimeoutSeconds: 30
+    directRetryIntervalSeconds: 120

--- a/config/examples/relay-wss/agent-canary-daemonset.yaml
+++ b/config/examples/relay-wss/agent-canary-daemonset.yaml
@@ -1,31 +1,25 @@
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: wirekube-agent
+  name: wirekube-agent-wss-canary
   namespace: wirekube-system
   labels:
-    app: wirekube-agent
-    app.kubernetes.io/name: wirekube-agent
+    app.kubernetes.io/name: wirekube-agent-wss-canary
     app.kubernetes.io/component: agent
 spec:
   selector:
     matchLabels:
-      app: wirekube-agent
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+      app: wirekube-agent-wss-canary
   template:
     metadata:
       labels:
-        app: wirekube-agent
-        app.kubernetes.io/name: wirekube-agent
+        app: wirekube-agent-wss-canary
+        app.kubernetes.io/name: wirekube-agent-wss-canary
         app.kubernetes.io/component: agent
     spec:
       serviceAccountName: wirekube-agent
       hostNetwork: true
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirstWithHostNet
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
@@ -34,24 +28,20 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: wirekube.io/proxy-node
-                    operator: NotIn
+                  - key: wirekube.io/agent-canary
+                    operator: In
                     values:
                       - "true"
                   - key: kubernetes.io/os
                     operator: In
                     values:
                       - linux
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: wirekube-agent-proxy
-              topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 30
+      imagePullSecrets:
+        - name: ncloud-registry
       containers:
         - name: agent
-          image: inerplat/wirekube:v0.0.8-dev.15
+          image: inerplat/wirekube:v0.0.0-dev.14
           command: ["wirekube-agent"]
           args:
             - --node-name=$(NODE_NAME)
@@ -69,28 +59,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: WIREKUBE_INTERFACE
-              value: "wire_kube"
+              value: wire_kube
             - name: WIREKUBE_RELAY_TOKEN_FILE
               value: /var/run/secrets/wirekube-relay/token
-            # Do not put HTTP_PROXY/HTTPS_PROXY here for clusters where only a
-            # subset of nodes needs egress proxying. Label those nodes with
-            # wirekube.io/proxy-node=true and deploy the dedicated proxy-node
-            # example manifest instead.
-            #
-            # Bootstrap-only Kubernetes API override for nodes that cannot reach
-            # the in-cluster Service IP before WireKube routes exist:
-            # - name: WIREKUBE_KUBE_APISERVER
-            #   value: "https://YOUR_KUBE_APISERVER_ENDPOINT"
           securityContext:
-            # privileged is required to open /dev/net/tun on Ubuntu 24.04+
-            # hosts where containerd's default device cgroup denies TUN
-            # write even with CAP_NET_ADMIN. Older distros with permissive
-            # device cgroups could get by with capabilities alone, but the
-            # userspace engine needs the TUN device on every node so we
-            # enable privileged here.
             privileged: true
-            # Unconfined AppArmor: the default containerd profile denies
-            # TUN-related operations on Ubuntu 24.04.
             appArmorProfile:
               type: Unconfined
             capabilities:
@@ -107,11 +80,11 @@ spec:
               readOnly: true
           resources:
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: "1"
+              memory: 1Gi
             requests:
-              cpu: 10m
-              memory: 64Mi
+              cpu: 50m
+              memory: 128Mi
       volumes:
         - name: wireguard-keys
           hostPath:

--- a/config/examples/relay-wss/httproute.yaml
+++ b/config/examples/relay-wss/httproute.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wirekube-relay-wss
+  namespace: wirekube-system
+spec:
+  parentRefs:
+    - name: istio-gateway
+      namespace: istio-ingress
+      sectionName: https
+  hostnames:
+    - relay.example.com
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /relay
+      backendRefs:
+        - name: wirekube-relay-ws
+          port: 8081
+      timeouts:
+        request: 0s
+        backendRequest: 0s

--- a/config/examples/relay-wss/wirekubemesh-external.yaml
+++ b/config/examples/relay-wss/wirekubemesh-external.yaml
@@ -1,0 +1,12 @@
+apiVersion: wirekube.io/v1alpha1
+kind: WireKubeMesh
+metadata:
+  name: default
+spec:
+  relay:
+    mode: auto
+    provider: external
+    external:
+      endpoint: "REPLACE_WITH_RAW_UDP_RELAY:3478"
+      controlEndpoint: "wss://relay.example.com/relay"
+      transport: wss

--- a/config/relay/deployment.yaml
+++ b/config/relay/deployment.yaml
@@ -1,10 +1,7 @@
 ---
 # wirekube-relay ServiceAccount + RBAC
 #
-# The relay process itself needs no Kubernetes permissions. The admin-web
-# sidecar uses this ServiceAccount to list, issue, and delete
-# WireKubeExternalPeer resources from a localhost-only web UI, and stores
-# generated client configs in namespaced Secrets.
+# The raw relay uses WireKube peer resources, while the optional WebSocket gateway uses TokenReview and bound Pod lookup. The admin-web sidecar manages WireKubeExternalPeer resources and generated client Secrets.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -23,6 +20,18 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
   - create
   - delete
 - apiGroups:

--- a/config/relay/example-managed.yaml
+++ b/config/relay/example-managed.yaml
@@ -1,6 +1,6 @@
 ---
-# Example: WireKubeMesh with operator-managed relay.
-# Operator automatically deploys a relay Pod + LoadBalancer Service.
+# Example: WireKubeMesh using an in-cluster relay.
+# Deploy config/relay/deployment.yaml separately; the current agent does not create or scale relay workloads from this resource.
 apiVersion: wirekube.io/v1alpha1
 kind: WireKubeMesh
 metadata:

--- a/config/relay/websocket.yaml
+++ b/config/relay/websocket.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wirekube-relay-ws
+  namespace: wirekube-system
+  labels:
+    app.kubernetes.io/name: wirekube-relay-ws
+    app.kubernetes.io/component: relay
+    app.kubernetes.io/part-of: wirekube
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wirekube-relay-ws
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: wirekube-relay-ws
+        app.kubernetes.io/component: relay
+    spec:
+      serviceAccountName: wirekube-relay
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: wirekube-relay-ws
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: relay-ws
+          image: inerplat/wirekube:v0.0.0-dev.14
+          command: ["wirekube-relay-ws"]
+          args:
+            - --addr=:8081
+            - --backend-addr=wirekube-relay.wirekube-system.svc.cluster.local:3478
+            - --path=/relay
+            - --audience=wirekube-relay
+            - --agent-service-account=wirekube-system/wirekube-agent
+          ports:
+            - name: relay-ws
+              containerPort: 8081
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 96Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wirekube-relay-ws
+  namespace: wirekube-system
+  labels:
+    app.kubernetes.io/name: wirekube-relay-ws
+    app.kubernetes.io/component: relay
+    app.kubernetes.io/part-of: wirekube
+spec:
+  selector:
+    app.kubernetes.io/name: wirekube-relay-ws
+  ports:
+    - name: http-websocket
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: wirekube-relay-ws
+  namespace: wirekube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wirekube-relay-ws

--- a/docs/architecture/cni-compatibility.md
+++ b/docs/architecture/cni-compatibility.md
@@ -6,15 +6,14 @@ with Cilium.
 
 ## Route Isolation
 
-WireKube only adds `/32` routes for node IPs with metric 200:
+WireKube places peer and gateway AllowedIPs in routing table `22347`, selected by an IP rule at priority `200`:
 
 ```
-10.0.0.2/32 dev wire_kube metric 200   <- WireKube
+10.0.0.2/32 dev wire_kube table 22347  <- WireKube
 10.244.0.0/24 dev cilium_host           <- CNI (lower metric = higher priority)
 ```
 
-Pod CIDR routes are **never** inserted through `wire_kube`. This prevents
-conflicts with CNI-managed routing, especially Cilium's kube-proxy replacement.
+Operators should keep mesh and gateway AllowedIPs from overlapping CNI-managed routes unless that routing behavior is intentional.
 
 ## Cilium BPF cgroup Hooks
 
@@ -28,8 +27,7 @@ Cilium attaches eBPF programs to cgroup socket operations:
 | `BPF_CGROUP_UDP4_RECVMSG` | `cil_sock4_recvmsg` | `recvfrom()` / `recvmsg()` |
 
 These hooks implement Cilium's socket-level load balancing for services.
-However, they can intercept UDP packets from the WireKube agent's relay proxy,
-potentially returning `EPERM`.
+The current userspace Bind delivers relay packets directly and normally avoids the legacy localhost UDP proxy. The behavior in this section applies to the retained UDPProxy fallback path and older deployments.
 
 ### When Does This Happen?
 
@@ -44,9 +42,9 @@ The hook does **not** trigger when:
 1. Using `write(2)` on a **connected** UDP socket (no `msg_name`)
 2. The container runs in the host cgroup (some configurations)
 
-### WireKube's Solution
+### Legacy UDPProxy Solution
 
-The relay UDP proxy uses `net.DialUDP` to create a **connected** UDP socket:
+The fallback relay UDP proxy uses `net.DialUDP` to create a **connected** UDP socket:
 
 ```go
 conn, _ := net.DialUDP("udp4", localAddr, remoteAddr)
@@ -115,12 +113,10 @@ WireKube uses `fwmark` 0x574B to prevent WireGuard packet loops:
 # WireGuard marks its own UDP packets with fwmark 0x574B
 # This rule ensures marked packets use the main routing table
 # (bypassing the wire_kube interface)
-ip rule add fwmark 0x574B lookup main priority 100
+ip rule add fwmark 0x574B lookup main priority 110
 ```
 
-Without this, a WireGuard UDP packet destined for a peer's node IP would
-match the `/32` route through `wire_kube`, get encrypted again, creating
-an infinite loop.
+The exact fwmark priority is dynamic: WireKube chooses at least `110`, places it after the current local-table rule, and keeps it below the WireKube table rule at priority `200`. Without this rule, a WireGuard UDP packet destined for a peer AllowedIP could re-enter the tunnel recursively.
 
 ## Tested CNI Plugins
 

--- a/docs/architecture/nat-traversal.md
+++ b/docs/architecture/nat-traversal.md
@@ -62,12 +62,7 @@ All major cloud NAT gateways use Symmetric NAT:
 Most home/ISP routers use Cone NAT (STUN-based P2P works).
 
 !!! info "When is relay needed?"
-    Relay is needed only when **both** peers are behind Symmetric NAT. Cone ↔
-    Symmetric pairs achieve direct P2P: the Symmetric side initiates a
-    handshake to the Cone peer's stable STUN endpoint; the Cone NAT accepts
-    the packet (Endpoint-Independent Filtering), and WireGuard responds to
-    the actual source address. Each node publishes its `natType` in its
-    WireKubePeer status, so peers can determine the optimal transport path.
+    Relay is required whenever direct probing cannot establish a usable path. Symmetric ↔ Symmetric is the common case, but restrictive firewalls, port-restricted mappings, and asymmetric filtering can also require relay. Each node publishes its `natType` so peers can choose an appropriate probe strategy.
 
 ## Traversal Strategy
 
@@ -271,22 +266,20 @@ When relay is activated for a peer:
 
 1. Agent connects to the relay server (or relay pool) via TCP
 2. Registers its WireGuard public key with the relay
-3. Creates a local UDP proxy (`127.0.0.1:random → 127.0.0.1:<wg-port>`)
-4. Sets the peer's WireGuard endpoint to the proxy's local address
-5. All subsequent WireGuard traffic for this peer routes through the relay
+3. Sets the userspace Bind path for that peer to relay or warm mode
+4. Bind sends encrypted WireGuard packets through the relay transport while preserving the direct endpoint for later probing
+5. Incoming relay packets are delivered directly from the relay pool to the userspace Bind
 
-The relay connection auto-reconnects with exponential backoff (1s–30s) if the
-TCP connection drops. Existing UDP proxies are preserved across reconnections.
+The relay connection auto-reconnects with exponential backoff (1s–30s) if the TCP connection drops. Bind path state remains available while the relay client reconnects.
 
 ### Stage 4: Direct Path Recovery
 
-Every `directRetryIntervalSeconds` (default 120s), the agent probes relayed
-peers to check if direct connectivity has become available:
+Every `directRetryIntervalSeconds` (default 120s), the agent probes relayed peers to check if direct connectivity has become available:
 
-1. Temporarily set the peer's WireGuard endpoint back to the direct address
-2. Wait for the next sync cycle to check WireGuard stats
-3. If a successful handshake is detected on the non-proxy endpoint → upgrade to direct
-4. If no handshake → cancel probe, resume relay, wait for next retry interval
+1. Move the peer from relay to warm mode so direct and relay can run together
+2. Observe direct receive evidence and WireGuard health
+3. Promote to direct when the direct path becomes healthy
+4. Demote to relay when the probe fails and wait for the next retry interval
 
 !!! note "Skipping futile probes"
     The agent skips direct probes for peers whose `WireKubePeer.Status.NATType`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -25,21 +25,18 @@ graph TD
     A3 <-->|WireGuard P2P or Relay| A1
 ```
 
-WireKube consists of four binaries:
+WireKube consists of the following deployed components:
 
 | Component | Runs as | Purpose |
 |-----------|---------|---------|
 | **Agent** | DaemonSet (`hostNetwork: true`) | Manages WireGuard interface, discovers endpoints, syncs peers, handles relay failover, direct recovery, and gateway forwarding |
-| **Operator** | Deployment | Reconciles `WireKubeMesh`, `WireKubePeer`, and `WireKubeGateway` CRDs, applies defaults |
 | **Relay** | Deployment + Service | Bridges WireGuard UDP over TCP for peers behind Symmetric NAT |
 | **wirekubectl** | CLI | Status inspection and peer management |
+| **Admin web** | Relay sidecar | Manages external peers through the Kubernetes API |
 
 ### Agent (DaemonSet)
 
-The agent runs on every node labeled with `wirekube.io/vpn-enabled=true`
-(`hostNetwork: true`, `privileged: true`, `appArmorProfile: Unconfined` —
-required for TUN open on Ubuntu 24.04 + containerd ≥ 1.7). It is
-responsible for:
+The default manifest runs the agent on every node except nodes labeled `wirekube.io/proxy-node=true`. It uses `hostNetwork: true`, `privileged: true`, and `appArmorProfile: Unconfined`, which are required for reliable TUN access on common Ubuntu 24.04 and containerd configurations. The agent is responsible for:
 
 1. **Userspace WireGuard** — Runs wireguard-go and owns a TUN named `wire_kube`. The kernel WireGuard backend has been removed; on upgrade from older versions the agent deletes any existing kernel `wire_kube` link and recreates it as a TUN.
 2. **Custom `WireKubeBind`** — Sits between wireguard-go and the network and runs the bimodal warm-relay datapath (see [NAT Traversal](nat-traversal.md)). Also sends and receives `MsgBimodalHint` disco frames via the relay for asymmetric-failover recovery.
@@ -50,19 +47,21 @@ responsible for:
 7. **NAT detection** — RFC 5780 multi-server STUN to classify `open` / `cone` / `port-restricted-cone` / `symmetric`
 8. **Relay client** — Connects to the relay pool and stays connected (relay is always warm, not just a fallback)
 9. **Relay auto-reconnect** — Exponential backoff (1s–30s) on TCP connection drops
-10. **Route management** — Adds `/32` routes for peer node IPs with metric 200
+10. **Route management** — Adds connected peer and gateway AllowedIPs to routing table 22347
 11. **IPSec bypass** — Sets `disable_xfrm` and `disable_policy` on the WireGuard interface
-12. **Crash recovery** — initContainer cleans stale interfaces, routes, and ip rules
+12. **State reconciliation** — Repairs routing rules during sync and removes interface state during graceful shutdown
 
 ### Relay Server
 
 The relay server bridges WireGuard UDP packets over TCP for peers behind Symmetric NAT.
-It is a stateless packet forwarder that:
+It is a connection-stateful packet forwarder that:
 
 - Accepts TCP connections from agents
 - Maps WireGuard public keys to TCP connections
 - Forwards framed UDP packets between agents
 - Cannot decrypt traffic (no access to WireGuard private keys)
+- Sees relay metadata such as registered public keys, peer relationships, frame sizes, and timing unless an outer TLS transport is used
+- Does not currently authenticate ownership of a registered WireGuard public key
 - Supports auto-reconnect from agents with exponential backoff
 - Can be scaled horizontally via a Headless Service (relay pool)
 
@@ -105,15 +104,14 @@ WireKube creates a **node-level mesh**, not a pod-level overlay.
 ### Route Strategy
 
 ```
-                     CNI routes (metric ~100)
+                     Main/CNI routing tables
 Pod A ---- pod CIDR ---- CNI (Cilium, etc.) ---- Pod B
 
-                     WireKube routes (metric 200)
-Node A ---- nodeIP/32 ---- wire_kube ---- Node B
+                     WireKube table 22347
+Node A ---- AllowedIP ---- wire_kube ---- Node B
 ```
 
-WireKube inserts **only `/32` routes for node IPs** with metric 200.
-Pod CIDR routes managed by the CNI are untouched (lower metric = higher priority).
+WireKube installs connected peer AllowedIPs and gateway CIDRs in table `22347`. An IP rule at priority `200` consults that table and falls through to the main table when no WireKube route matches.
 
 !!! warning "Critical Design Rule"
     Never insert pod CIDR routes through `wire_kube`. This would break CNI
@@ -123,7 +121,7 @@ Pod CIDR routes managed by the CNI are untouched (lower metric = higher priority
 
 - **fwmark `0x574B`** on WireGuard socket packets → main routing table (avoids packet loop)
 - **Custom routing table `22347`** (`0x574B`) isolates WireGuard routes from the main table
-- **Route metric 200** (above CNI default ~100, so CNI takes precedence)
+- **IP rule priority 200** selects the WireKube table; routes themselves do not set metric 200
 - **`disable_xfrm=1`** and **`disable_policy=1`** on wire_kube → bypasses IPSec xfrm policies
 
 ### Packet Path (Direct P2P)
@@ -142,13 +140,13 @@ Pod CIDR routes managed by the CNI are untouched (lower metric = higher priority
 ```
 1. Packet destined for remote node IP
 2. Kernel routing: nodeIP/32 → dev wire_kube
-3. WireGuard encrypts → UDP to local proxy (127.0.0.1:random)
-4. UDP proxy reads packet → frames as [4B length][1B type=0x02][32B dest pubkey][payload]
-5. Sends over TCP to relay server (via relay pool)
-6. Relay forwards to destination agent's TCP connection
-7. Destination proxy delivers UDP to local WireGuard (127.0.0.1:51820)
-8. WireGuard decrypts
-9. Delivered to local stack
+3. WireGuard encrypts the packet and the custom userspace Bind selects the relay leg
+4. Bind frames the encrypted packet as [4B length][1B type=0x02][32B dest pubkey][payload]
+5. Relay pool sends the frame over TCP to a relay server
+6. Relay forwards it to the destination agent's TCP connection
+7. Destination relay client delivers the encrypted packet directly to the destination Bind
+8. WireGuard decrypts the packet
+9. Packet is delivered to the local stack
 ```
 
 ## NAT Traversal Overview
@@ -156,19 +154,19 @@ Pod CIDR routes managed by the CNI are untouched (lower metric = higher priority
 Inspired by [Tailscale's approach](https://tailscale.com/blog/how-nat-traversal-works):
 
 1. **STUN discovery** — Query 2+ STUN servers; compare mapped ports for NAT type detection
-2. **Direct P2P** — Same VPC or Cone NAT nodes handshake directly
-3. **Relay fallback** — Symmetric NAT or handshake timeout → TCP relay with auto-reconnect
-4. **Direct recovery** — Periodic probing upgrades relayed peers back to direct when possible
+2. **Relay availability** — When configured, relay connects immediately and provides the safe starting path
+3. **Direct promotion** — Same-VPC and compatible NAT pairs are probed and promoted to direct
+4. **Continuous recovery** — Stale direct paths demote to relay and are periodically probed again
 
 See [NAT Traversal](nat-traversal.md) for the full strategy.
 
 ## Design Principles
 
 1. **Cloud-agnostic** — No reliance on cloud-specific features (VPC peering, etc.)
-2. **CNI-safe** — Only routes node IPs, never pod CIDRs
-3. **Graceful degradation** — Direct P2P → relay fallback → direct recovery
-4. **Minimal privileges** — `NET_ADMIN` + `SYS_MODULE` only, no `privileged: true`
+2. **CNI-aware** — Keeps WireKube routes in a dedicated table and expects operators to avoid overlapping AllowedIPs; gateway routes may intentionally include non-node CIDRs
+3. **Graceful path selection** — Relay availability → direct promotion → relay recovery on failure
+4. **Explicit privileges** — The bundled userspace-WireGuard DaemonSet uses `privileged: true`, `NET_ADMIN`, `SYS_MODULE`, an unconfined AppArmor profile, and a mounted TUN device
 5. **Structured direct upgrade** — Relayed peers are periodically probed; skips peers that self-report as relay-only (Symmetric NAT)
 6. **Per-node status ownership** — Each agent updates only its own `transportMode` to prevent cross-agent status flapping
 7. **IPSec coexistence** — xfrm bypass prevents conflicts with existing site-to-site tunnels
-8. **Crash resilience** — initContainer cleanup + routing table isolation
+8. **State repair** — Graceful cleanup plus periodic routing rule reconciliation

--- a/docs/architecture/relay.md
+++ b/docs/architecture/relay.md
@@ -8,21 +8,17 @@ that cannot establish direct P2P connections (Symmetric NAT, restrictive firewal
 ```mermaid
 flowchart LR
     subgraph NodeA["Node A (Symmetric NAT)"]
-        WG1[WireGuard wire_kube]
-        P1[UDP Proxy 127.0.0.1:random]
-        WG1 <--> P1
+        WG1[wireguard-go + WireKubeBind]
     end
     subgraph RelayPool["Relay Pool"]
         R1[relay-0 :3478]
         R2[relay-1 :3478]
     end
     subgraph NodeB["Node B"]
-        P2[UDP Proxy 127.0.0.1:random]
-        WG2[WireGuard wire_kube]
-        P2 <--> WG2
+        WG2[wireguard-go + WireKubeBind]
     end
-    P1 <-->|TCP| RelayPool
-    RelayPool <-->|TCP| P2
+    WG1 <-->|Relay frames over TCP| RelayPool
+    RelayPool <-->|Relay frames over TCP| WG2
 ```
 
 ## Protocol
@@ -46,6 +42,12 @@ All messages are framed with a length prefix:
 | `MsgKeepalive` | `0x03` | (empty) | Keep TCP connection alive (30s interval) |
 | `MsgNATProbe` | `0x04` | 4-byte IPv4 + 2-byte port | Ask relay to send a UDP probe back to the agent — used for port-restriction detection |
 | `MsgBimodalHint` | `0x05` | 32-byte dest pubkey (server rewrites to sender pubkey on forward) | Disco-style asymmetric-failure signal; instructs the destination peer to dual-send on both direct and relay legs |
+| `MsgRelayProbe` | `0x06` | 8-byte token | Measure relay-to-agent responsiveness |
+| `MsgForwarderRegister` | `0x10` | UDP port + ingress key + external key | Legacy external-peer forwarder registration |
+| `MsgForwarderUnregister` | `0x11` | UDP port | Legacy external-peer forwarder removal |
+| `MsgForwarderStats` | `0x12` | UDP port and counters | Legacy forwarder statistics |
+| `MsgIngressProbe` | `0x13` | ingress key list or RTT result list | Probe candidate external-peer ingress agents |
+| `MsgExternalData` | `0x20` | source token + source address + WireGuard payload | Carry shared-listener external-peer traffic |
 | `MsgError` | `0xFF` | Error message string | Relay reports an error |
 
 !!! note "Why a separate hint frame"
@@ -56,7 +58,7 @@ All messages are framed with a length prefix:
     me" request to the peer through the already-warm relay, so failover
     converges within the trust window instead of waiting for the FSM to
     time out the path (~30s). The relay rewrites the body to the sender
-    pubkey so the receiver can authenticate who sent it.
+    pubkey so the receiver can associate the hint with a peer. This is relay-provided identity metadata, not cryptographic proof that the sender owns that WireGuard key.
 
 ### Connection Lifecycle
 
@@ -67,7 +69,6 @@ sequenceDiagram
     Agent->>Relay: TCP connect
     Agent->>Relay: MsgRegister(myPubKey)
     Note over Relay: maps pubkey → conn
-    Relay-->>Agent: ready
     Agent->>Relay: MsgData(destPubKey, payload)
     Note over Relay: lookup destPubKey → forward
     Relay->>Agent: MsgData(srcPubKey, payload)
@@ -86,64 +87,30 @@ The relay client implements automatic reconnection with exponential backoff:
 - **Trigger**: Any read/write error on the TCP connection, or connection close
 - **Behavior**: Sets `connected=false`, closes the old connection, signals reconnect
 - **Registration**: On reconnect, re-sends `MsgRegister` to re-associate the public key
-- **Proxy persistence**: Existing UDP proxies are preserved across reconnections
+- **Path persistence**: Bind relay path state remains configured while clients reconnect
 
 The `connected` state is tracked via `atomic.Bool` for lock-free access from
 the agent's main sync loop.
 
-## Local UDP Proxy
+## Userspace Bind Delivery
 
-Each relayed peer gets a dedicated UDP proxy running on localhost.
+The current agent uses wireguard-go with `WireKubeBind`. Relay packets do not need to be translated through a localhost UDP proxy in the default userspace path.
 
-### Why a Local Proxy?
+### Outbound Path
 
-WireGuard is a kernel-level interface that speaks UDP only. It cannot
-directly use a TCP connection. The proxy bridges this gap:
+`WireKubeBind.Send` selects direct, warm, or relay delivery per peer. On the relay leg it hands the already encrypted WireGuard packet to the relay pool, which writes a `MsgData` frame over TCP.
 
 ```mermaid
 flowchart LR
-    WG[WireGuard kernel] -->|UDP| P[Proxy 127.0.0.1:random]
-    P -->|TCP| R[Relay Pool]
+    WG[wireguard-go] --> B[WireKubeBind]
+    B -->|MsgData over TCP| R[Relay Pool]
 ```
 
-### Socket Strategy
+### Inbound Path
 
-The proxy uses `net.DialUDP` to create a **connected** UDP socket:
+The relay pool parses the incoming frame and invokes Bind delivery with the sender key and encrypted payload. Wireguard-go then authenticates and decrypts the inner WireGuard packet.
 
-```go
-localAddr  := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
-remoteAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: wgPort}
-conn, _ := net.DialUDP("udp4", localAddr, remoteAddr)
-```
-
-This gives the proxy a stable local address (e.g., `127.0.0.1:54321`) that
-WireGuard uses as the peer's endpoint. Since the socket is **connected** to
-the WireGuard port, `conn.Write()` uses `write(2)` instead of `sendto(2)`,
-which is important for [Cilium compatibility](cni-compatibility.md).
-
-### Adaptive Write
-
-The proxy implements a two-tier write strategy:
-
-1. **Standard**: `conn.Write(payload)` — uses Go's `net.UDPConn`
-2. **Fallback**: `syscall.Write(dupFD, payload)` — raw syscall on a duplicated fd
-
-If `conn.Write()` returns `EPERM` (e.g., from Cilium BPF hooks), the proxy
-switches to `syscall.Write` mode for all subsequent writes. This is tracked
-via an `atomic.Bool` for lock-free access.
-
-### Sender Interface
-
-The proxy sends data through a `Sender` interface:
-
-```go
-type Sender interface {
-    SendToPeer(destPubKey [32]byte, payload []byte) error
-}
-```
-
-This abstraction allows the proxy to work with either a single `Client` or
-the `Pool`, making the relay layer pluggable.
+The legacy `UDPProxy` implementation remains in the codebase as a fallback for engines without direct Bind delivery, but it is not the normal path of the bundled userspace engine.
 
 ## Relay Pool
 
@@ -201,7 +168,7 @@ metadata:
 spec:
   clusterIP: None
   selector:
-    app: wirekube-relay
+    app.kubernetes.io/name: wirekube-relay
   ports:
     - port: 3478
       targetPort: 3478
@@ -216,22 +183,11 @@ local UDP proxy based on the source WireGuard public key:
 Relay → Pool.handleData(srcKey, payload) → proxies[srcKey].DeliverToWireGuard(payload)
 ```
 
-## Managed Relay Discovery
+## Managed Relay Endpoint
 
-For `provider: managed`, the agent needs to connect to the relay before the mesh
-tunnel is up (chicken-and-egg problem). The agent resolves this by querying the
-Kubernetes Service API for the relay's externally reachable address:
+For `provider: managed`, the agent connects to the headless `wirekube-relay-control.<namespace>.svc.cluster.local` Service. This is the simplest path for nodes with working cluster DNS and service routing.
 
-1. **ExternalIPs** — Manually configured public IPs on the Service
-2. **LoadBalancer Ingress** — Cloud-assigned external IP or hostname
-3. **NodePort** — Service NodePort via a cluster node's public IP (ExternalIP
-   or public InternalIP for cloud providers like OCI)
-
-ClusterIP DNS is intentionally **not** used as a fallback because CoreDNS
-resolution depends on a functioning CNI, which may not be available on
-hybrid/NAT'd nodes before the mesh tunnel is established. If no external address
-is found, the agent retries with exponential backoff until the Service becomes
-externally reachable (e.g., LoadBalancer IP is assigned).
+Nodes that cannot reach that Service during bootstrap must use `provider: external`. Set `external.endpoint` to the relay's public LoadBalancer address or a reachable node IP and NodePort. The relay process is the same; only the agent's entry point changes.
 
 ## Deployment Options
 
@@ -281,8 +237,16 @@ Internet ---- TCP LB :3478 ---- Relay Pod/Server :3478
 The relay's TCP transport was specifically designed to work with TCP-only
 load balancer offerings.
 
+HTTP application load balancers and Kubernetes Ingress controllers generally cannot carry this raw TCP protocol. See [Relay Entry Points](../guides/relay-entrypoints.md) for the recommended LoadBalancer path, the NodePort alternative, and HTTP CONNECT forward-proxy examples.
+
+The proposed [WebSocket Relay Endpoint](websocket-relay.md) adds `wss://.../relay` with Kubernetes-issued bearer-token authentication for ALB and Ingress environments.
+
 ## Capacity
 
-A single relay instance can handle thousands of concurrent connections.
-Each connection is a lightweight TCP socket with minimal CPU overhead —
-the relay only forwards opaque encrypted packets without any decryption.
+Each agent connection is a TCP socket and the relay does not decrypt the inner WireGuard payload. Capacity has not yet been published from a repeatable load-test benchmark, so operators should validate connection and bandwidth limits for their workload.
+
+## Security Boundary
+
+WireGuard payloads remain end-to-end encrypted, but the raw relay TCP stream exposes registered public keys, source/destination relationships, frame types, sizes, timing, NAT probe targets, and external-peer source metadata. The current `MsgRegister` flow does not prove ownership of the supplied WireGuard public key, so a public relay should not be treated as an authenticated control plane.
+
+The optional public HTTP endpoint uses WebSocket over TLS and a Kubernetes-issued bearer token. TLS protects the outer relay stream and server identity; the token authenticates and authorizes the connecting agent. See [WebSocket Relay Endpoint](websocket-relay.md).

--- a/docs/architecture/websocket-relay.md
+++ b/docs/architecture/websocket-relay.md
@@ -1,0 +1,103 @@
+# WebSocket Relay Endpoint
+
+Status: implemented as the optional `wirekube-relay-ws` gateway.
+
+## Goal
+
+Expose the WireKube relay as `wss://relay.example.com/relay` so agents can connect through HTTP-aware load balancers and Ingress controllers while preserving the existing relay frame protocol and WireGuard end-to-end encryption.
+
+## Why WebSocket over HTTPS
+
+Binding the raw relay protocol to TCP port 443 does not make it HTTPS and does not make it compatible with ALB or HTTP Ingress. WebSocket provides a standard HTTP Upgrade handshake, a long-lived bidirectional stream, and broad support across ALB, reverse proxies, Ingress controllers, and enterprise networks.
+
+The external connection is WSS. TLS may terminate in the relay process or at a trusted ALB/Ingress, with an internal WebSocket hop from the terminator to the relay. End-to-end TLS to the relay Pod is preferable when the cluster network is not trusted.
+
+## Connection Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant LB as ALB or Ingress
+    participant Relay
+    participant API as Kubernetes TokenReview API
+    Agent->>LB: GET /relay, Upgrade: websocket, Authorization: Bearer token
+    LB->>Relay: Forward WebSocket upgrade
+    Relay->>API: TokenReview(token, audience=wirekube-relay)
+    API-->>Relay: authenticated identity and bound-object metadata
+    Relay-->>LB: 101 Switching Protocols
+    LB-->>Agent: 101 Switching Protocols
+    Agent->>Relay: MsgRegister(publicKey)
+    Agent->>Relay: Existing relay frames inside WebSocket
+    Relay->>Agent: Existing relay frames inside WebSocket
+```
+
+The bearer token must be sent in the `Authorization` header and never in the URL. Query-string tokens leak through access logs, browser history, proxy metrics, and tracing systems.
+
+## Token UX
+
+Use Kubernetes ServiceAccount tokens with a dedicated audience instead of mTLS client certificates. Kubernetes signs the token, supports expiry, exposes a standard TokenReview API, and already provides `kubectl` and projected-volume issuance flows.
+
+For an in-cluster DaemonSet, mount a projected ServiceAccount token with `audience: wirekube-relay` and a short expiration. Kubelet rotates the token automatically.
+
+For manual testing or an agent outside the normal DaemonSet flow, create a dedicated ServiceAccount whose identity is mapped to one WireKubePeer, then issue a short-lived token:
+
+```bash
+kubectl -n wirekube-system create serviceaccount wirekube-relay-peer-node-a
+kubectl -n wirekube-system create token wirekube-relay-peer-node-a --audience=wirekube-relay --duration=1h
+```
+
+The relay validates the token with Kubernetes TokenReview and accepts only configured ServiceAccounts, namespaces, and bound Pod or Node identities. TokenReview authentication alone is not enough if every agent shares the same unbound identity: the relay must bind the authenticated Pod, Node, or dedicated ServiceAccount identity to the expected `WireKubePeer.spec.publicKey` before accepting `MsgRegister`.
+
+`kubectl create token` tokens expire naturally but do not have a convenient per-token revocation object. Use short TTLs; for a dedicated manual ServiceAccount, deleting or removing authorization for that ServiceAccount revokes future TokenReview acceptance. A future `wirekubectl relay token issue --peer <name>` command can wrap ServiceAccount creation, token issuance, Secret storage, and cleanup without changing the underlying Kubernetes authentication model.
+
+For a relay running outside the cluster, TokenReview requires restricted Kubernetes API access. Offline JWT verification against the cluster issuer is possible but weakens immediate revocation; TokenReview is the preferred first implementation.
+
+## Authorization Model
+
+Authentication answers which Kubernetes workload presented the token. Authorization must additionally verify all of the following:
+
+1. Token audience is exactly `wirekube-relay`.
+2. Token is unexpired and accepted by TokenReview.
+3. ServiceAccount and namespace are allowlisted.
+4. Bound Pod or Node identity matches the connecting agent.
+5. Registered WireGuard public key matches the `WireKubePeer` owned by that node.
+6. A connection may register only one identity and cannot replace another node's authenticated session.
+
+This closes the current raw relay behavior where any client can register an arbitrary 32-byte public key and disconnect the previous connection using the same key.
+
+## Transport Shape
+
+Keep the existing relay frame format unchanged. The simplest Go implementation can adapt a WebSocket to `net.Conn` semantics and continue using `ReadFrame` and `WriteFrame`; alternatively, one complete WireKube frame can be carried in each binary WebSocket message. The stream adapter approach minimizes protocol changes, while message-per-frame makes limits and observability clearer.
+
+The endpoint should expose:
+
+| Path | Purpose |
+|------|---------|
+| `/relay` | Authenticated WebSocket relay stream |
+| `/healthz` | Process liveness without authentication |
+| `/readyz` | Readiness including raw relay backend connectivity |
+
+Reject normal HTTP bodies, unauthenticated upgrades, unsupported origins when browser access is enabled, oversized frames, and connections that do not register within a short deadline.
+
+## Configuration Shape
+
+The agent selects exactly one relay transport from `external.transport`. `tcp` uses the raw endpoint, while `ws` and `wss` require `external.controlEndpoint`. The raw `external.endpoint` remains separate because external WireGuard peers still need the UDP relay address.
+
+```yaml
+relay:
+  provider: external
+  external:
+    endpoint: "203.0.113.10:3478"
+    controlEndpoint: "wss://relay.example.com/relay"
+    transport: wss
+```
+
+For projected ServiceAccount tokens, `authSecretRef` is not required; the agent reads the rotated projected token from `/var/run/secrets/wirekube-relay/token`. `authSecretRef` remains reserved for manually issued tokens and non-DaemonSet clients.
+
+Do not override the selected endpoint with a DaemonSet environment variable. Upgrade every agent while the mesh remains on `transport: tcp`, verify the new version, then change the WireKubeMesh to `transport: wss` and restart agents in a controlled rollout. An old agent treats `controlEndpoint` as raw TCP and cannot safely consume a WSS URL.
+
+The WSS gateway should run with at least two replicas on different nodes. A single gateway replica turns one Pod or node failure into loss of every WSS relay session even though the raw TCP relay is still healthy.
+
+## Compatibility
+
+WSS is intended for HTTP-aware load balancers and Ingress controllers. Raw TCP remains the lower-overhead option for direct reachability, NLB, and NodePort. HTTP CONNECT remains a separate client-to-forward-proxy transport and should not be conflated with the relay's own WSS endpoint. Agents never keep raw TCP and WSS sessions active for the same public key at the same time because the relay permits only one active registration per public key.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -101,22 +101,23 @@ Generated files in `config/crd/` must be committed alongside type changes.
 wirekube/
 ├── cmd/
 │   ├── agent/           # Agent entrypoint
-│   ├── operator/        # Operator entrypoint
+│   ├── admin-web/       # External-peer management web UI
 │   ├── relay/           # Relay server entrypoint
+│   ├── stun-server/     # Development STUN server
 │   └── wirekubectl/     # CLI entrypoint
 ├── pkg/
 │   ├── agent/           # Agent logic (endpoint discovery, peer sync)
 │   │   ├── nat/         # STUN and UPnP endpoint discovery
-│   │   └── relay/       # Relay client, UDP proxy, relay pool
+│   │   └── relay/       # Relay client, Bind delivery fallback proxy, relay pool
 │   │       ├── client.go   # TCP client with auto-reconnect
-│   │       ├── proxy.go    # Per-peer UDP proxy (Sender interface)
+│   │       ├── proxy.go    # Legacy/fallback per-peer UDP proxy
 │   │       └── pool.go     # Multi-instance relay pool
-│   ├── api/v1alpha1/    # CRD types (WireKubeMesh, WireKubePeer)
-│   ├── controller/      # Kubernetes controller-runtime reconcilers
+│   ├── api/v1alpha1/    # Mesh, peer, gateway, and external-peer CRD types
+│   ├── controller/      # Embedded external-peer reconciler and stub legacy reconcilers
 │   ├── relay/           # Relay server and wire protocol
 │   └── wireguard/       # WireGuard interface, routing, xfrm bypass
 ├── config/
-│   ├── agent/           # DaemonSet manifest (includes RBAC)
+│   ├── agent/           # Separate RBAC, DaemonSet, and ServiceMonitor manifests
 │   ├── crd/             # CustomResourceDefinition YAMLs (generated)
 │   ├── relay/           # Relay deployment + service examples
 │   └── examples/         # WireKubeMesh and EKS Hybrid Node examples

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -45,19 +45,20 @@ spec:
 | `spec.stunServers` | []string | - | STUN servers for endpoint discovery. **Minimum 2 required** for Symmetric NAT detection (RFC 5780). |
 | `spec.relay.mode` | string | `auto` | `auto`, `always`, or `never` |
 | `spec.relay.provider` | string | - | `external` or `managed` |
-| `spec.relay.handshakeTimeoutSeconds` | int | `30` | Seconds to wait for direct handshake before relay fallback |
+| `spec.relay.handshakeTimeoutSeconds` | int | `30` | Retained API field. The current PathMonitor-based relay-first flow does not consume this value after initialization. |
 | `spec.relay.directRetryIntervalSeconds` | int | `120` | How often to retry direct connection after falling back to relay |
 | `spec.relay.external.endpoint` | string | - | External relay server address (`host:port`) |
-| `spec.relay.external.transport` | string | `tcp` | Relay transport protocol |
-| `spec.relay.managed.replicas` | int | `1` | Number of relay pods |
-| `spec.relay.managed.serviceType` | string | `LoadBalancer` | Kubernetes Service type for the relay |
+| `spec.relay.external.controlEndpoint` | string | - | Agent-facing endpoint. Required as a `ws://` or `wss://` URL when the selected transport is WebSocket. |
+| `spec.relay.external.transport` | string | `tcp` | Selects exactly one agent transport: `tcp`, `ws`, or `wss`. |
+| `spec.relay.managed.replicas` | int | `1` | Desired relay replicas in the API shape. The current agent does not provision or scale the Deployment from this field. |
+| `spec.relay.managed.serviceType` | string | `LoadBalancer` | Desired Service type in the API shape. The current agent does not create or mutate the Service from this field. |
 | `spec.relay.managed.port` | int | `3478` | Relay service port |
 
 ### Relay Modes
 
 | Mode | Behavior |
 |------|----------|
-| `auto` | Try direct P2P first; fall back to relay after `handshakeTimeoutSeconds`. Periodically re-probe direct. |
+| `auto` | Connect relay-first for immediate reachability, probe the direct path, and promote peers to direct when receive evidence is healthy. Periodically re-probe direct after demotion. |
 | `always` | Always use relay (useful for testing or highly restrictive networks) |
 | `never` | Never use relay; only direct P2P |
 
@@ -65,8 +66,8 @@ spec:
 
 | Provider | Description |
 |----------|-------------|
-| `external` | User-provided relay endpoint. Agent connects to the configured `external.endpoint`. |
-| `managed` | Relay deployed as Deployment + Service in the cluster. Agent auto-discovers the Service's external address (ExternalIP → LB Ingress → NodePort) so NAT'd nodes can connect without relying on CNI tunnels. Does **not** fall back to ClusterIP DNS. |
+| `external` | User-provided relay endpoint. The agent selects `external.endpoint` or `external.controlEndpoint` according to `external.transport`. |
+| `managed` | Relay deployed separately in the cluster. Agents connect through the cluster-local `wirekube-relay-control` Service; WireKube does not currently create the Deployment or Service from the CR. Use `external` with a public LB, NodePort, or WSS endpoint when cluster DNS/service routing is unavailable during bootstrap. |
 
 ## Node Labels and Annotations
 
@@ -74,7 +75,7 @@ spec:
 
 | Label | Description |
 |-------|-------------|
-| `wirekube.io/vpn-enabled=true` | Node participates in the mesh |
+| `wirekube.io/proxy-node=true` | Excludes the node from the standard DaemonSet and selects it for the dedicated HTTP-proxy DaemonSet example. |
 
 ### Annotations
 
@@ -85,7 +86,6 @@ spec:
 Example:
 
 ```bash
-kubectl label node my-node wirekube.io/vpn-enabled=true
 kubectl annotate node my-node wirekube.io/endpoint="203.0.113.5:51820"
 ```
 
@@ -99,10 +99,13 @@ kubectl annotate node my-node wirekube.io/endpoint="203.0.113.5:51820"
 
 ### Security Context
 
-The agent requires two capabilities:
+The bundled userspace-WireGuard DaemonSet uses the following security context:
 
 ```yaml
 securityContext:
+  privileged: true
+  appArmorProfile:
+    type: Unconfined
   capabilities:
     add: ["NET_ADMIN", "SYS_MODULE"]
 ```
@@ -110,22 +113,19 @@ securityContext:
 - **NET_ADMIN** — Create/delete WireGuard interfaces, manage routes and routing rules
 - **SYS_MODULE** — Load the `wireguard` kernel module if not already loaded
 
-`privileged: true` is **not required**.
+`privileged: true` is currently enabled because common Ubuntu 24.04 and containerd configurations deny `/dev/net/tun` access with capabilities alone.
 
 ### DNS Policy
 
-The DaemonSet uses `dnsPolicy: ClusterFirstWithHostNet`. Since the agent runs with
-`hostNetwork: true`, this setting ensures it can resolve cluster-internal DNS names
-for Kubernetes API and other services.
+The bundled DaemonSet currently uses `dnsPolicy: Default`. If `provider: managed` is used, the node resolver must be able to resolve `wirekube-relay-control.<namespace>.svc.cluster.local`; otherwise change the policy to `ClusterFirstWithHostNet` or use an externally reachable relay endpoint.
 
-### initContainer Cleanup
+### Cleanup and Reconciliation
 
-The DaemonSet includes an `initContainer` that cleans up stale state from previous
-agent runs (crashes, reboots):
+The default DaemonSet does not include an initContainer. During graceful shutdown the agent removes the relay clients, routes, routing rules, and TUN interface. During startup and periodic sync it recreates or repairs required interface and routing state.
 
-- Removes the `wire_kube` interface if it exists
-- Flushes the WireKube routing table (`22347` / `0x574B`)
-- Removes stale `ip rule` entries for the WireKube fwmark
+- Graceful shutdown removes the `wire_kube` interface and WireKube routes
+- Routing rule reconciliation repairs missing or stale rules
+- The separate cleanup Job is available for abandoned node state
 
 ### IPSec xfrm Bypass
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,6 +18,12 @@ Tagged releases are built automatically via GitHub Actions on tag push (`v*`).
 kubectl apply -f config/crd/
 ```
 
+Create the namespace used by the bundled manifests:
+
+```bash
+kubectl create namespace wirekube-system --dry-run=client -o yaml | kubectl apply -f -
+```
+
 ### 2. WireKubeMesh Resource
 
 Create a mesh configuration. See [Configuration](configuration.md) for all options.
@@ -28,16 +34,14 @@ kubectl apply -f config/examples/wirekubemesh-basic.yaml
 
 ### 3. Agent DaemonSet
 
-The DaemonSet manifest includes RBAC (ServiceAccount, ClusterRole, ClusterRoleBinding)
-and the agent container definition. No separate RBAC step is needed.
+RBAC and the DaemonSet are separate manifests:
 
 ```bash
+kubectl apply -f config/agent/rbac.yaml
 kubectl apply -f config/agent/daemonset.yaml
 ```
 
-The DaemonSet runs with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`.
-An `initContainer` performs cleanup of stale WireGuard interfaces, routing rules, and
-routing table entries from previous runs.
+The DaemonSet runs with `hostNetwork: true`, `dnsPolicy: Default`, `privileged: true`, and `appArmorProfile: Unconfined`. It does not include an initContainer; the agent removes routes and the TUN interface during graceful shutdown and reconciles stale routing state during startup and periodic sync.
 
 ### 4. (Optional) Relay
 
@@ -46,6 +50,8 @@ For managed relay:
 ```bash
 kubectl apply -f config/relay/deployment.yaml
 ```
+
+The bundled relay Deployment has an EKS-specific `eks.amazonaws.com/nodegroup: relay-ng` node selector. Remove or replace it for other clusters.
 
 See [Relay Architecture](../architecture/relay.md) for external relay, managed relay,
 and scaling options.
@@ -105,9 +111,7 @@ Deploy as a Kubernetes Deployment + Service:
 kubectl apply -f config/relay/deployment.yaml
 ```
 
-The agent auto-discovers the relay's external address by checking the Service for
-ExternalIP, LoadBalancer Ingress, or NodePort. This solves the bootstrap problem
-where NAT'd nodes cannot reach ClusterIP before the mesh tunnel is up.
+Managed agents connect to the cluster-local `wirekube-relay-control` Service. Use an external provider endpoint when an agent must enter through the public LoadBalancer, NodePort, or an HTTP CONNECT proxy. See [Relay Entry Points](../guides/relay-entrypoints.md).
 
 ### Option B: External (Standalone)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,10 +16,12 @@ Get WireKube running on your Kubernetes cluster in 5 minutes.
 kubectl apply -f config/crd/
 ```
 
-This creates two Custom Resource Definitions:
+This creates four Custom Resource Definitions:
 
 - **WireKubeMesh** — Global mesh configuration (listen port, STUN servers, relay settings)
 - **WireKubePeer** — Per-node peer state (auto-managed by the agent)
+- **WireKubeGateway** — Virtual gateway routes and failover configuration
+- **WireKubeExternalPeer** — Off-cluster WireGuard client authorization and status
 
 ## Step 2: Create a Mesh
 
@@ -64,19 +66,16 @@ spec:
 ## Step 3: Deploy the Agent
 
 ```bash
+kubectl create namespace wirekube-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f config/agent/rbac.yaml
 kubectl apply -f config/agent/daemonset.yaml
 ```
 
-The agent DaemonSet runs on every labeled node with `hostNetwork: true` and
-`dnsPolicy: ClusterFirstWithHostNet` (required for in-cluster DNS resolution).
+The default agent DaemonSet runs on every node except nodes labeled `wirekube.io/proxy-node=true`. It uses `hostNetwork: true`, `dnsPolicy: Default`, userspace WireGuard, and a privileged security context for TUN access.
 
-## Step 4: Label Nodes
+## Step 4: Choose Agent Placement
 
-Only nodes with the `wirekube.io/vpn-enabled=true` label participate in the mesh:
-
-```bash
-kubectl label node <node-name> wirekube.io/vpn-enabled=true
-```
+The current default manifest does not use `wirekube.io/vpn-enabled=true` as a scheduling gate. To restrict participation, add your own node affinity or node selector to `config/agent/daemonset.yaml` before applying it.
 
 ## Step 5: (Optional) Deploy the Relay
 
@@ -84,7 +83,10 @@ For managed relay (in-cluster):
 
 ```bash
 kubectl apply -f config/relay/deployment.yaml
+kubectl apply -f config/relay/example-managed.yaml
 ```
+
+The relay manifest currently contains an EKS-specific `eks.amazonaws.com/nodegroup: relay-ng` node selector. Remove or replace it before applying the manifest to another cluster.
 
 For external relay on a public server:
 
@@ -92,7 +94,7 @@ For external relay on a public server:
 wirekube-relay --addr :3478
 ```
 
-See [Relay Architecture](../architecture/relay.md) for details on relay modes and scaling.
+See [Relay Architecture](../architecture/relay.md) for details on relay modes and scaling. If your cluster cannot provision a public LoadBalancer, or some nodes use an HTTP CONNECT proxy, follow [Relay Entry Points](../guides/relay-entrypoints.md).
 
 ## Step 6: Set AllowedIPs
 
@@ -123,10 +125,10 @@ ping <other-node-ip>
 2. The agent registers itself as a `WireKubePeer` CRD
 3. STUN queries two servers to discover the public endpoint and detect NAT type
 4. If mapped ports differ between STUN servers → Symmetric NAT detected
-5. WireGuard handshakes are attempted with all discovered peers
-6. If handshake times out (or Symmetric NAT detected), relay fallback activates
-7. Routes are added: `<node-ip>/32 dev wire_kube metric 200`
-8. Periodically, the agent re-probes relayed peers for direct connectivity upgrade
+5. When relay is configured, new peers start with relay availability while direct probing runs
+6. Healthy direct receive evidence promotes a peer to direct; failed or stale paths remain on relay
+7. Connected AllowedIPs are installed in routing table `22347`, selected by an IP rule at priority `200`
+8. The agent periodically re-probes relayed peers for direct connectivity
 
 ## Next Steps
 

--- a/docs/guides/eks-hybrid-nodes.md
+++ b/docs/guides/eks-hybrid-nodes.md
@@ -9,7 +9,7 @@ WireKube establishes a WireGuard mesh VPN across all nodes, enabling:
 - **Encrypted node-to-node connectivity** over WireGuard tunnels
 - **Cross-node pod networking** via Cilium VXLAN over WireGuard
 - **kubectl exec/logs/port-forward** on hybrid nodes (via Virtual Gateway)
-- **Automatic NAT traversal** with STUN + relay fallback
+- **Automatic NAT traversal** with STUN, relay-first availability, and direct-path promotion
 
 ---
 
@@ -59,10 +59,8 @@ graph TB
 
 ### Connection Strategy
 
-1. **Direct P2P** — STUN discovers NAT-mapped endpoints; nodes connect
-   directly when NAT allows it (Cone ↔ Cone, Cone ↔ Symmetric)
-2. **Relay fallback** — After 30s handshake timeout, traffic flows through
-   the TCP relay (WireGuard encryption preserved end-to-end)
+1. **Relay availability** — Agents connect to the TCP relay during startup so a safe path is ready immediately
+2. **Direct promotion** — STUN discovers NAT-mapped endpoints and compatible peers move to direct when receive evidence proves the path
 3. **Birthday attack** — Optional port-prediction for Symmetric ↔ Symmetric
    NAT pairs behind CGNAT
 4. **VGW gateway** — EC2 forwards VPC traffic to hybrid nodes through
@@ -463,10 +461,7 @@ kubectl exec <hybrid-pod-A> -- wget -qO- --timeout=5 http://<hybrid-pod-B-IP>
 
 ### fwmark Design
 
-WireGuard's kernel module marks its own encrypted UDP packets with
-`fwmark 0x574b`. The ip rule at priority 100 sends these to the main
-routing table, preventing them from re-entering the `wire_kube` interface
-(which would create an infinite encryption loop).
+The userspace WireGuard Bind marks encrypted UDP packets with `fwmark 0x574b`. The agent places a dynamic main-table rule after the local-table rule and before priority `200`, preventing marked packets from re-entering the `wire_kube` interface.
 
 ---
 

--- a/docs/guides/relay-entrypoints.md
+++ b/docs/guides/relay-entrypoints.md
@@ -1,0 +1,135 @@
+# Relay Entry Points
+
+WireKube recommends a public `LoadBalancer` Service for the relay. It gives agents one stable address and lets the cloud provider manage node replacement. When that is not available, the same relay can be exposed through NodePort or reached through an HTTP CONNECT forward proxy.
+
+## Choose an entry point
+
+| Environment | Relay endpoint | Agent proxy setting |
+|-------------|----------------|---------------------|
+| Cloud LB available | `<load-balancer-host>:3478` | Disabled |
+| No LB, public cluster node available | `<public-node-ip>:30478` | Disabled |
+| Node using an HTTP CONNECT proxy | Either endpoint above | `WIREKUBE_RELAY_PROXY=environment` |
+| HTTP-aware LB or Ingress | `wss://<host>/relay` | Kubernetes-issued bearer token |
+
+The base relay protocol is raw TCP, not HTTP. A TCP load balancer such as AWS NLB is compatible. A typical HTTP application load balancer or Kubernetes Ingress cannot forward the raw endpoint, so deploy the optional [WebSocket Relay Endpoint](../architecture/websocket-relay.md) when the entry point must use HTTPS/WSS.
+
+## Recommended: public LoadBalancer
+
+The default relay manifest creates the recommended public entry point:
+
+Before applying it outside the EKS example environment, remove or replace the hard-coded `eks.amazonaws.com/nodegroup: relay-ng` selector in `config/relay/deployment.yaml`.
+
+```bash
+kubectl apply -f config/relay/deployment.yaml
+kubectl -n wirekube-system get service wirekube-relay
+```
+
+Keep the mesh on `provider: managed` when every agent can resolve and reach the cluster-local `wirekube-relay-control` Service. For nodes that bootstrap outside cluster networking, use `provider: external` and set the public LB address:
+
+```yaml
+relay:
+  mode: auto
+  provider: external
+  external:
+    endpoint: "relay.example.com:3478"
+    transport: tcp
+```
+
+## Alternative: NodePort
+
+Deploy the relay, then change its public Service to NodePort:
+
+```bash
+kubectl apply -f config/relay/deployment.yaml
+kubectl apply -f config/examples/relay-nodeport/service.yaml
+kubectl -n wirekube-system get service wirekube-relay
+```
+
+The second apply updates the existing Service; it does not create a second relay entry point. A cloud provider may briefly start provisioning a load balancer between the two commands, then removes it after the Service type changes.
+
+The example fixes both TCP and UDP to NodePort `30478`. TCP carries agent relay connections. UDP is used by external WireGuard peers; it can remain blocked if that feature is not used.
+
+Choose a stable, reachable node address and configure it as an external relay:
+
+```bash
+sed 's/REPLACE_WITH_PUBLIC_NODE_IP/203.0.113.10/' \
+  config/examples/relay-nodeport/wirekubemesh-external.yaml | kubectl apply -f -
+```
+
+Before deploying agents, verify the path from the same network as the node:
+
+```bash
+nc -vz 203.0.113.10 30478
+```
+
+NodePort does not provide address failover by itself. Keep the selected node IP stable, or place a DNS record or external TCP load balancer in front of multiple NodePort-capable nodes.
+
+## Through an HTTP(S) forward proxy
+
+WireKube uses the standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables. The agent sends an HTTP `CONNECT` request to the proxy, then carries the relay's raw TCP stream through the tunnel.
+
+Label only the nodes that require the proxy and deploy the dedicated DaemonSet:
+
+```bash
+kubectl label node <node> wirekube.io/proxy-node=true
+kubectl apply -f config/agent/rbac.yaml
+kubectl apply -f config/examples/http-proxy-node/daemonset.yaml
+```
+
+In that manifest, configure:
+
+```yaml
+- name: WIREKUBE_RELAY_PROXY
+  value: "environment"
+- name: HTTPS_PROXY
+  value: "http://proxy.example.com:3128"
+- name: HTTP_PROXY
+  value: "http://proxy.example.com:3128"
+```
+
+The relay endpoint may be either form:
+
+```yaml
+# Public LB / TCP LB
+endpoint: "relay.example.com:3478"
+
+# NodePort reached through the same forward proxy
+endpoint: "203.0.113.10:30478"
+```
+
+The proxy must allow CONNECT to the selected destination port. Do not add the relay host to `NO_PROXY`, or the agent will bypass the proxy. Proxying applies to the TCP relay control/data stream only; external-peer UDP cannot traverse an HTTP CONNECT proxy.
+
+This forward-proxy flow is distinct from the WSS relay endpoint. CONNECT tunnels the existing raw TCP protocol through another proxy; WSS makes the relay itself an authenticated HTTP Upgrade endpoint.
+
+## Through an HTTPS/WSS entry point
+
+Deploy the WSS gateway separately from the raw relay, expose it through an HTTPS Gateway or Ingress, and keep at least two gateway replicas on different nodes:
+
+```bash
+kubectl apply -f config/relay/websocket.yaml
+sed 's/relay.example.com/relay.your-domain.example/' config/examples/relay-wss/httproute.yaml | kubectl apply -f -
+```
+
+Select WSS in the WireKubeMesh. This is the only production transport selector; do not force an endpoint through the agent DaemonSet environment:
+
+```yaml
+relay:
+  mode: auto
+  provider: external
+  external:
+    endpoint: "203.0.113.10:3478"
+    controlEndpoint: "wss://relay.your-domain.example/relay"
+    transport: wss
+```
+
+`transport: tcp` uses the raw endpoint and does not open a WebSocket session. `transport: wss` uses only `controlEndpoint` and keeps `endpoint` for NAT probing and external WireGuard peers. Running both Services is safe because they are entry points to the same relay, but one agent public key must not connect through both transports simultaneously.
+
+## Verify the selected path
+
+```bash
+kubectl -n wirekube-system logs daemonset/wirekube-agent-proxy \
+  | grep -E 'relay connected|relay initial connect failed|proxy'
+kubectl get wirekubepeers -o wide
+```
+
+If the direct path is unavailable, peer connection status should converge to `relay`. See [Troubleshooting](../operations/troubleshooting.md) when CONNECT is rejected or the NodePort is unreachable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 **Connect Kubernetes nodes across any network — no VPN server required.**
 
-WireKube builds a WireGuard mesh between your Kubernetes nodes using only CRDs for coordination. It automatically handles NAT traversal, falls back to TCP relay when direct P2P isn't possible, and preserves WireGuard's end-to-end encryption throughout.
+WireKube builds a WireGuard mesh between your Kubernetes nodes using CRDs for coordination. It keeps a relay path available when configured, probes direct connectivity, and preserves WireGuard payload encryption across both paths.
 
 The NAT traversal design draws from [Tailscale's architecture](https://tailscale.com/blog/how-nat-traversal-works): relay-first for immediate connectivity, parallel direct path probing, and transparent upgrade when a better path is found.
 
@@ -43,10 +43,10 @@ flowchart LR
 | Feature | Description |
 |---------|-------------|
 | **No coordination server** | Kubernetes CRDs are the only control plane — no external dependencies |
-| **Automatic NAT traversal** | STUN discovery → direct P2P → TCP relay fallback, fully automatic |
+| **Automatic NAT traversal** | STUN discovery + relay-first availability + direct-path promotion |
 | **Direct path recovery** | Periodically re-probes relayed peers and upgrades to direct when possible |
 | **Virtual Gateway** | Cross-VPC routing with HA failover via `WireKubeGateway` CRD |
-| **CNI compatible** | Routes only node IPs (`/32`); never touches pod CIDRs |
+| **CNI aware** | Uses an isolated routing table; mesh and gateway AllowedIPs must not conflict with CNI routes |
 | **Relay pool scaling** | DNS-based multi-instance relay discovery with automatic failover |
 | **Prometheus metrics** | Peer latency, traffic, connection state, transport mode on `:9090/metrics` |
 | **Multi-arch** | `linux/amd64` and `linux/arm64` |

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -64,38 +64,34 @@ Key log messages:
 
 | Log Pattern | Meaning |
 |-------------|---------|
-| `endpoint discovered: X.X.X.X:51820 via stun` | STUN discovery succeeded |
-| `symmetric NAT detected` | Node behind Symmetric NAT |
-| `peer handshake completed` | Direct P2P working |
-| `handshake timeout, activating relay` | Falling back to relay |
-| `relay connected` | TCP connection to relay established |
-| `relay-pool: connected to new replica` | New relay instance joined pool |
-| `peer X: upgraded to direct` | Relayed peer successfully probed for direct |
-| `peer X: direct probe failed, staying on relay` | Direct probe attempt failed |
-| `EPERM detected, switching to raw syscall.Write` | Cilium BPF bypass activated |
-| `xfrm bypass enabled on wire_kube` | IPSec xfrm bypass set |
+| `[stun] symmetric NAT detected` | STUN servers observed endpoint-dependent port mappings |
+| `relay connected` | Agent initialized a relay pool endpoint |
+| `relay-client: connected to` | A relay TCP client connected and registered |
+| `path monitor: new peer, starting on relay` | New peer entered the safe relay-first path |
+| `upgraded to direct (relay proxy in standby)` | A direct path was proven and promoted |
+| `active probe failed, reverting to relay` | Direct probing failed and relay remained active |
+| `relay-client: reconnect failed` | Relay reconnect is backing off after a failure |
+| `[wireguard] xfrm bypass enabled` | IPSec xfrm bypass was applied |
 
 ## Prometheus Metrics
 
-The agent exposes Prometheus metrics on `:9090/metrics`. Use the provided
-ServiceMonitor (`config/agent/servicemonitor.yaml`) for Prometheus Operator
-auto-discovery. It selects `app.kubernetes.io/name=wirekube-agent`, so the
-standard agent DaemonSet and the proxy-node agent DaemonSet are scraped by the
-same ServiceMonitor.
+The agent exposes Prometheus metrics on `:9090/metrics`. The provided Service selects Pods with `app.kubernetes.io/name=wirekube-agent`, including the standard and proxy-node DaemonSets, and the ServiceMonitor selects that Service by its `app=wirekube-agent` label.
 
 ### Available Metrics
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `wirekube_peer_latency_seconds` | Gauge | peer, endpoint, transport | ICMP RTT to peer |
-| `wirekube_peer_bytes_sent_total` | Gauge | peer | Total bytes sent via WireGuard |
-| `wirekube_peer_bytes_received_total` | Gauge | peer | Total bytes received via WireGuard |
-| `wirekube_peer_connected` | Gauge | peer, nat_type | Connection status (1=connected, 0=disconnected) |
-| `wirekube_peer_transport_mode` | Gauge | peer | Transport (1=direct, 2=relay, 3=mixed) |
-| `wirekube_peer_last_handshake_seconds` | Gauge | peer | Seconds since last WireGuard handshake |
-| `wirekube_node_nat_type` | Gauge | node | NAT type (1=cone, 2=symmetric, 0=unknown) |
+| `wirekube_peer_latency_seconds` | Gauge | source, peer, transport | ICMP RTT to peer |
+| `wirekube_peer_bytes_sent_total` | Gauge | source, peer | Total bytes sent via WireGuard |
+| `wirekube_peer_bytes_received_total` | Gauge | source, peer | Total bytes received via WireGuard |
+| `wirekube_peer_connected` | Gauge | source, peer, nat_type | Connection status (1=connected, 0=disconnected) |
+| `wirekube_peer_transport_mode` | Gauge | source, peer | Transport (1=direct, 2=relay) |
+| `wirekube_peer_last_handshake_seconds` | Gauge | source, peer | Seconds since last WireGuard handshake |
+| `wirekube_node_nat_type` | Gauge | node | NAT type (0=unknown, 1=cone, 2=symmetric, 3=port-restricted-cone, 4=open) |
 | `wirekube_peers_total` | Gauge | — | Total WireKubePeer count |
 | `wirekube_relayed_peers_total` | Gauge | — | Peers currently using relay |
+| `wirekube_direct_peers_total` | Gauge | — | Peers currently using direct P2P |
+| `wirekube_peer_ice_state` | Gauge | source, peer | ICE state (0=relay, 1=gathering, 2=checking, 3=connected, 4=birthday, 5=failed) |
 
 ### Grafana Dashboard
 

--- a/docs/operations/node-management.md
+++ b/docs/operations/node-management.md
@@ -2,24 +2,18 @@
 
 ## Agent Restart Behavior
 
-The WireKube agent preserves the WireGuard kernel interface and routes across
-pod restarts. Because WireGuard operates at the kernel level, direct P2P tunnels
-continue forwarding traffic even while the agent process is restarting.
+The current agent runs wireguard-go in userspace. A rolling restart or process failure interrupts direct and relay forwarding until the new agent process recreates or reattaches the TUN and restores peer state.
 
-On startup, the agent validates the existing interface:
+On startup, the agent validates the interface name and type:
 
-- **Key matches:** The interface is reused as-is. STUN discovery may fail
-  (port already bound), but the existing CR endpoint is preserved.
-- **Key mismatch:** The interface is torn down and recreated with the new key.
+- **Existing userspace TUN:** The engine attempts to reattach and configure it.
+- **Legacy kernel WireGuard link:** The engine deletes it and migrates to a userspace TUN.
+- **Foreign interface with the same name:** Startup fails rather than deleting an interface it does not own.
 
-User-space resources (relay TCP connections, ICE negotiation, metrics) are
-released on shutdown and re-established on the next startup. Relay connections
-reconnect automatically with exponential backoff (1–30 seconds).
+During graceful shutdown the agent closes relay connections, flushes WireKube routes, removes routing rules, and deletes the TUN interface. Relay connections reconnect with exponential backoff after the next startup.
 
-!!! info "Zero-downtime for direct tunnels"
-    Pod restarts (rolling updates, OOM kills, node reboots) cause **no
-    disruption** to direct WireGuard P2P tunnels. Relay-based connections
-    experience a brief reconnection window (typically under 30 seconds).
+!!! note "Restart impact"
+    Restart duration depends on pod scheduling, Kubernetes API access, endpoint discovery, and relay availability. Treat agent restarts as a short network interruption and use rollout settings appropriate for the workload.
 
 ---
 
@@ -71,12 +65,8 @@ NODE=<node-name> && \
   sed "s/TARGET_NODE_NAME/$NODE/g" config/cleanup/cleanup-job.yaml | kubectl apply -f -
 ```
 
-!!! warning "DaemonSet label"
-    If the `wirekube.io/vpn-enabled=true` label is still on the node, the
-    DaemonSet will reschedule the agent after cleanup. Remove the label first:
-    ```bash
-    kubectl label node <node-name> wirekube.io/vpn-enabled-
-    ```
+!!! warning "DaemonSet placement"
+    The default DaemonSet targets every node except `wirekube.io/proxy-node=true` nodes. Before running the cleanup Job, change the DaemonSet affinity or otherwise prevent the standard agent Pod from being recreated on the target node.
 
 ---
 

--- a/docs/operations/topologies.md
+++ b/docs/operations/topologies.md
@@ -106,11 +106,7 @@ flowchart LR
 | Home ↔ Home (same LAN) | Direct | Same network |
 | Cloud (Symmetric) ↔ Cloud (Symmetric, different VPC) | Relay | Both behind Symmetric NAT |
 
-Home routers typically use Cone NAT (Endpoint-Independent Mapping).
-In WireKube, Cone ↔ Symmetric pairs achieve direct P2P: the Symmetric
-side initiates a WireGuard handshake to the Cone peer's stable STUN
-endpoint. Relay is only needed when **both** peers are behind Symmetric
-NAT, which happens in cross-VPC cloud-to-cloud communication.
+Home routers typically use Cone NAT (Endpoint-Independent Mapping). Cone ↔ Symmetric pairs often achieve direct P2P, while Symmetric ↔ Symmetric and restrictive firewall or filtering combinations commonly remain on relay.
 
 ## Topology 5: Air-Gapped with Outbound TCP
 
@@ -139,9 +135,10 @@ ports need to be opened on the node's firewall.
 graph TD
     A[All nodes have<br/>public IPs?] -->|Yes| B[No relay needed<br/>mode: never]
     A -->|No| C[Any nodes behind<br/>Symmetric NAT?]
-    C -->|No| D[STUN P2P works<br/>mode: auto, relay unlikely]
+    C -->|No| D[Direct path likely<br/>mode: auto can promote direct]
     C -->|Yes| E[Deploy relay<br/>mode: auto]
     E --> F{Where to deploy relay?}
     F -->|Public server| G[External relay]
-    F -->|In-cluster| H[Managed relay<br/>+ LoadBalancer or NodePort]
+    F -->|In-cluster DNS reachable| H[Managed relay<br/>control Service]
+    F -->|HTTP-aware LB / Ingress| I[Planned WSS relay]
 ```

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -85,8 +85,8 @@ nc -zv <relay-endpoint> 3478
 # Check relay pods
 kubectl get pods -n wirekube-system -l app=wirekube-relay
 
-# Check Service external address (for managed relay)
-kubectl get svc wirekube-relay -n wirekube-system -o wide
+# Check the cluster-local control Service for managed relay
+kubectl get svc wirekube-relay-control -n wirekube-system -o wide
 ```
 
 **Fix:**
@@ -94,9 +94,10 @@ kubectl get svc wirekube-relay -n wirekube-system -o wide
 The relay client auto-reconnects with exponential backoff (1s–30s). If the relay
 is persistently unreachable:
 
-1. Check firewall / security group rules (TCP 3478 inbound)
-2. For managed relay, verify the Service has an ExternalIP or LoadBalancer IP
-3. After fixing, the agent reconnects automatically — no restart needed
+1. Check firewall or security group rules for the selected relay endpoint
+2. For managed relay, verify cluster DNS and routing to `wirekube-relay-control.<namespace>.svc.cluster.local`
+3. For external relay, verify the public LoadBalancer or NodePort address
+4. After fixing, the agent reconnects automatically without a restart
 
 ---
 
@@ -172,17 +173,16 @@ kubectl patch wirekubepeer <name> --type merge \
 
 ```bash
 ip rule show | grep 0x574B
-# Should show: 100: from all fwmark 0x574B lookup main
+# Should show a main-table fwmark rule below the local-table rule and above priority 200
 ```
 
 **Fix:**
 
 ```bash
-ip rule add fwmark 0x574B lookup main priority 100
+ip rule add fwmark 0x574B lookup main priority 110
 ```
 
-The agent creates this rule automatically on startup. The initContainer also
-removes stale rules from previous runs.
+The agent creates and repairs this rule automatically. The exact priority is dynamic and may be greater than `110` when the host moves the local-table rule.
 
 ---
 
@@ -198,7 +198,7 @@ RTNETLINK answers: File exists
 
 **Fix:**
 
-The DaemonSet's initContainer cleans up stale interfaces on startup. For manual fix:
+The default DaemonSet has no initContainer. The userspace engine attempts to reattach an existing TUN, migrates a legacy kernel WireGuard link, and refuses to delete a foreign interface. For manual cleanup of abandoned WireKube state:
 
 ```bash
 ip link del wire_kube 2>/dev/null
@@ -253,29 +253,23 @@ kubectl patch wirekubepeer <name> --type merge \
 
 ---
 
-## Scenario 10: Managed Relay Unreachable
+## Scenario 10: Managed Relay DNS or Service Unreachable
 
 **Symptoms:**
 
-Agent logs show `managed relay: no externally reachable address found on wirekube-relay Service`.
+The agent repeatedly fails to connect to `wirekube-relay-control.wirekube-system.svc.cluster.local:3478`.
 
-**Root Cause:** The managed relay Service does not have an ExternalIP, LoadBalancer
-Ingress, or NodePort with a reachable node IP. The agent does **not** use
-ClusterIP/CoreDNS for relay discovery because it may be unreachable on hybrid/NAT'd
-nodes before the mesh tunnel is established.
+**Root Cause:** `provider: managed` uses the cluster-local relay control Service, but this node cannot resolve cluster DNS or route to Services during bootstrap.
 
 **Fix:**
 
-Ensure the relay Service has an externally reachable address:
+Verify the control Service and DNS from the affected node. If cluster service routing cannot be made available before WireKube starts, switch the mesh to `provider: external` and use the relay's public LoadBalancer or NodePort address:
 
 ```bash
-kubectl get svc wirekube-relay -n wirekube-system -o wide
+kubectl get svc wirekube-relay-control -n wirekube-system -o wide
 ```
 
-If using `serviceType: LoadBalancer`, wait for the external IP to be assigned.
-For `NodePort`, ensure at least one cluster node has a public IP (ExternalIP or
-a public InternalIP). The agent retries relay initialization with exponential
-backoff, so it will connect once the external address becomes available.
+See [Relay Entry Points](../guides/relay-entrypoints.md) for LoadBalancer, NodePort, and HTTP CONNECT proxy configurations.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -15,13 +15,26 @@ wirekube-agent --node-name <name> [flags]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--node-name` | Kubernetes node name (required) | - |
+| `--pod-name` | Agent Pod name used for metrics annotations | `POD_NAME` |
+| `--pod-namespace` | Agent Pod namespace | `POD_NAMESPACE` |
+| `--mesh-name` | WireKubeMesh resource name | `default` |
+| `--interface` | WireGuard interface name override | `WIREKUBE_INTERFACE` or mesh value |
+| `--listen-port` | WireGuard UDP listen port fallback | `51820` |
+| `--mtu` | WireGuard interface MTU fallback | `1420` |
+| `--kube-apiserver` | Kubernetes API server URL override | `WIREKUBE_KUBE_APISERVER` |
+| `--metrics-addr` | Metrics and health HTTP listen address | `:9090` |
 
 ### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NODE_NAME` | Alternative to `--node-name` flag | - |
+| `POD_NAME` | Alternative to `--pod-name` | - |
+| `POD_NAMESPACE` | Alternative to `--pod-namespace` | - |
 | `WIREKUBE_INTERFACE` | Override WireGuard interface name | From WireKubeMesh |
+| `WIREKUBE_KUBE_APISERVER` | Bootstrap Kubernetes API server URL | In-cluster configuration |
+| `WIREKUBE_RELAY_PROXY` | Relay proxy policy (`environment` or `disabled`) | `disabled` |
+| `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` | Standard proxy environment used when relay proxy mode is enabled | - |
 | `KUBECONFIG` | Path to kubeconfig file | In-cluster config |
 
 ### Behavior
@@ -33,8 +46,8 @@ wirekube-agent --node-name <name> [flags]
 5. Watches all WireKubePeer CRDs for changes
 6. Configures WireGuard peers and routes
 7. Connects to relay pool (if configured) with auto-reconnect
-8. Monitors handshakes; activates relay fallback if needed
-9. Periodically probes relayed peers for direct upgrade
+8. Starts peers with relay availability when configured and monitors direct-path health
+9. Promotes healthy direct paths and reverts stale paths to relay
 10. Sets `disable_xfrm` and `disable_policy` on the WireGuard interface
 
 ---
@@ -54,12 +67,20 @@ wirekube-relay --addr <listen-address>
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--addr` | TCP listen address | `:3478` |
+| `--forwarder-port-low` | Lowest legacy external-peer UDP forwarder port | `0` (disabled) |
+| `--forwarder-port-high` | Highest legacy external-peer UDP forwarder port | `0` (disabled) |
+| `--external-wg-addr` | Shared raw-WireGuard UDP listener | empty (disabled) |
+| `--external-wg-ingress-pubkey` | Fixed ingress WireGuard public key for the shared listener | empty (dynamic fanout) |
 
 ### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `WIREKUBE_RELAY_ADDR` | Alternative to `--addr` flag | `:3478` |
+| `WIREKUBE_FORWARDER_PORT_LOW` | Alternative to `--forwarder-port-low` | `0` |
+| `WIREKUBE_FORWARDER_PORT_HIGH` | Alternative to `--forwarder-port-high` | `0` |
+| `WIREKUBE_EXTERNAL_WG_ADDR` | Alternative to `--external-wg-addr` | empty |
+| `WIREKUBE_EXTERNAL_WG_INGRESS_PUBKEY` | Alternative to `--external-wg-ingress-pubkey` | empty |
 
 ### Example
 
@@ -79,5 +100,13 @@ CLI tool for inspecting mesh status.
 ```bash
 wirekubectl mesh status
 wirekubectl peers
-wirekubectl peer <peer-name>
+wirekubectl export
+wirekubectl import <file>
+wirekubectl token create
+wirekubectl external list
+wirekubectl external get <name>
+wirekubectl external invite <display-name> [flags]
+wirekubectl external revoke <display-name>
 ```
+
+`wirekubectl token create` is currently a placeholder that prints guidance and does not issue a token. The WSS relay uses Kubernetes `kubectl create token` and TokenReview instead.

--- a/docs/reference/crds.md
+++ b/docs/reference/crds.md
@@ -57,30 +57,31 @@ spec:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `mode` | string | No | `auto` | `auto`: try direct first, fallback to relay. `always`: always relay. `never`: direct only |
-| `provider` | string | No | - | `external`: user-provided relay. `managed`: deployed within the cluster |
-| `handshakeTimeoutSeconds` | int | No | `30` | Seconds to wait for direct handshake before activating relay |
+| `mode` | string | No | `auto` | `auto`: start with relay available and promote healthy peers to direct. `always`: always relay. `never`: direct only |
+| `provider` | string | No | - | `external`: connect to a user-provided endpoint. `managed`: connect to the separately deployed cluster-local relay control Service. |
+| `handshakeTimeoutSeconds` | int | No | `30` | Retained API field. The current PathMonitor relay-first flow stores this value but does not use it for path transitions. |
 | `directRetryIntervalSeconds` | int | No | `120` | Seconds between attempts to upgrade a relayed peer back to direct P2P |
 
 #### `spec.relay.external`
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `endpoint` | string | Yes (if external) | - | Relay server address (`host:port`) |
-| `transport` | string | No | `tcp` | Transport protocol (`tcp`) |
+| `endpoint` | string | Yes (if external) | - | Raw relay address (`host:port`) used by TCP agents, NAT probing, and external WireGuard peers. |
+| `transport` | string | No | `tcp` | Selects exactly one agent transport: `tcp`, `ws`, or `wss`. |
+| `controlEndpoint` | string | Required for `ws`/`wss` | - | Agent-facing endpoint. It may be a separate raw address for `tcp` or a matching `ws://`/`wss://` URL. |
+| `authSecretRef` | SecretKeyRef | No | - | Reserved authentication configuration. The current relay client does not read this Secret or send a relay credential. |
 
 #### `spec.relay.managed`
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `replicas` | int | No | `1` | Number of relay pod replicas |
-| `serviceType` | string | No | `LoadBalancer` | Kubernetes Service type |
-| `port` | int | No | `3478` | Relay service port |
+| `replicas` | int | No | `1` | Desired replicas in the API shape; no controller currently reconciles this into a Deployment. |
+| `serviceType` | string | No | `LoadBalancer` | Desired Service type in the API shape; no controller currently reconciles this field. |
+| `port` | int | No | `3478` | Port used when constructing the cluster-local managed relay endpoint. |
+| `image` | string | No | - | Reserved deployment configuration; currently not reconciled. |
+| `resources` | RelayResources | No | - | Reserved deployment configuration; currently not reconciled. |
 
-When `provider: managed`, the agent discovers the relay's externally reachable
-address by querying the Service (ExternalIP → LB Ingress → NodePort). The agent
-does **not** fall back to ClusterIP DNS because CoreDNS may be unreachable on
-hybrid/NAT'd nodes before the mesh tunnel is established.
+When `provider: managed`, agents connect to the cluster-local `wirekube-relay-control` Service. The relay Deployment and Services must be installed separately. Nodes that cannot use cluster DNS or service routing during bootstrap should use `provider: external` with a reachable LoadBalancer, NodePort, or future WSS endpoint.
 
 For multi-instance scaling, use a Headless Service. The relay pool re-resolves
 DNS every 30s to track replica changes.
@@ -102,7 +103,7 @@ One per mesh-participating node.
 apiVersion: wirekube.io/v1alpha1
 kind: WireKubePeer
 metadata:
-  name: node-my-node
+  name: my-node
   labels:
     wirekube.io/node: my-node
 spec:
@@ -128,7 +129,7 @@ spec:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `connected` | bool | Whether a recent WireGuard handshake has been observed |
+| `connected` | bool | Whether the agent currently considers at least one usable transport path available |
 | `natType` | string | Detected NAT mapping behavior: `open` (no NAT — public IP on NIC), `cone`, `port-restricted-cone`, `symmetric`, or empty (undetermined). Published by the agent so other peers can decide transport path. |
 | `transportMode` | string | Aggregate transport state derived from `peerTransports`: `direct`, `relay`, or `mixed`. |
 | `peerTransports` | map[string]string | Per-peer transport mode. Key is peer CRD name (e.g., `node-worker7`), value is `direct` or `relay`. |
@@ -153,7 +154,7 @@ The `natType` and `transportMode` fields are shown as `NAT` and `Mode` columns i
 
 ### Naming Convention
 
-Peer resources are named `node-<node-name>` (e.g., `node-my-node`).
+Agent-managed peer resources use the Kubernetes Node name directly (for example, Node `worker-a` owns WireKubePeer `worker-a`).
 
 ---
 
@@ -248,3 +249,40 @@ spec:
 NAME             ACTIVE      READY   ROUTES   AGE
 vpc-b-gateway    node-b1     true    1        5m
 ```
+
+---
+
+## WireKubeExternalPeer
+
+| Property | Value |
+|----------|-------|
+| API Version | `wirekube.io/v1alpha1` |
+| Kind | `WireKubeExternalPeer` |
+| Scope | Cluster |
+| Short Name | `wkep` |
+
+WireKubeExternalPeer authorizes an off-cluster host that runs a standard WireGuard client. The external-peer reconciler is embedded in every agent Pod and uses leader election so only one agent performs allocation.
+
+### Spec
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `displayName` | string | Yes | Stable human-readable identity used by the deterministic mesh-IP allocator. |
+| `publicKey` | string | Yes | External client's 44-character base64 WireGuard public key. |
+| `ttl` | duration | No | Optional lifetime after which the CR is deleted. |
+| `allowedDestinations` | []string | No | CIDRs rendered into the external client's AllowedIPs. Defaults are resolved by the reconciler. |
+| `mtu` | int | No | Client MTU override; the effective default is `1248`. |
+| `ingressPeer` | string | No | Pins the client to a specific WireKubePeer; otherwise the reconciler selects an ingress peer. |
+
+### Status
+
+| Field | Description |
+|-------|-------------|
+| `assignedMeshIP` | Allocated overlay `/32`. |
+| `relayEndpoint` | Shared raw-WireGuard UDP endpoint rendered into the client configuration. |
+| `ingressPeerName` | Selected in-cluster ingress peer. |
+| `ingressPublicKey` | WireGuard public key authenticated by the external client. |
+| `allowedDestinations` | Effective AllowedIPs rendered for the client. |
+| `mtu` | Effective client MTU. |
+| `phase` | `Pending`, `Active`, `Revoked`, or `Failed`. |
+| `connected`, `lastHandshake` | Reserved health fields; the allocation reconciler does not currently populate them. |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/gorilla/websocket v1.5.0
 	github.com/huin/goupnp v1.3.0
 	github.com/pion/stun/v3 v3.0.0
 	github.com/prometheus/client_golang v1.19.1
@@ -41,7 +42,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,12 +59,14 @@ nav:
     - Configuration: getting-started/configuration.md
   - Guides:
     - Local Playground: guides/local-playground.md
+    - Relay Entry Points: guides/relay-entrypoints.md
     - EKS Hybrid Nodes: guides/eks-hybrid-nodes.md
     - WSL2 GPU Node: guides/wsl2-gpu-node.md
   - Architecture:
     - Overview: architecture/overview.md
     - NAT Traversal: architecture/nat-traversal.md
     - Relay System: architecture/relay.md
+    - WebSocket Relay: architecture/websocket-relay.md
     - Virtual Gateway: architecture/gateway.md
     - CNI Compatibility: architecture/cni-compatibility.md
   - Operations:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1383,7 +1383,12 @@ func (a *Agent) driveTransportMode(
 		if peer == nil || peer.Spec.PublicKey == "" {
 			continue
 		}
-		mode := a.pathMonitor.Evaluate(name, peer.Spec.PublicKey, false)
+		var mode PathMode
+		if a.relayMode == relayModeAlways {
+			mode = a.pathMonitor.ForceRelay(name, peer.Spec.PublicKey)
+		} else {
+			mode = a.pathMonitor.Evaluate(name, peer.Spec.PublicKey, false)
+		}
 		directAddr := peer.Spec.Endpoint
 		if ep, ok := a.directEndpoints[name]; ok && ep != "" {
 			directAddr = ep

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -1591,21 +1592,26 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 	}
 
 	var endpoint string
+	var probeAddr string
+	var relayTransport string
+	var tokenRequired bool
 	switch relay.Provider {
 	case "external":
-		if relay.External == nil || relay.External.Endpoint == "" {
-			return fmt.Errorf("external relay endpoint not configured")
+		config, err := externalRelayDialConfig(relay.External)
+		if err != nil {
+			return err
 		}
-		endpoint = relay.External.Endpoint
-		if relay.External.ControlEndpoint != "" {
-			endpoint = relay.External.ControlEndpoint
-		}
+		endpoint = config.endpoint
+		probeAddr = config.probeAddr
+		relayTransport = config.transport
+		tokenRequired = config.tokenRequired
 	case "managed":
 		port := int32(3478)
 		if relay.Managed != nil && relay.Managed.Port != 0 {
 			port = relay.Managed.Port
 		}
 		endpoint = managedRelayControlEndpoint(a.podNamespace, port)
+		relayTransport = "tcp"
 	default:
 		return fmt.Errorf("unknown relay provider: %s", relay.Provider)
 	}
@@ -1619,9 +1625,17 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 
 	wgPort := a.wgMgr.ListenPort()
 	a.relayPool = agentrelay.NewPool(endpoint, pubKey, wgPort)
+	a.relayPool.SetProbeAddr(probeAddr)
+	if tokenRequired {
+		tokenFile := os.Getenv("WIREKUBE_RELAY_TOKEN_FILE")
+		if tokenFile == "" {
+			tokenFile = "/var/run/secrets/wirekube-relay/token"
+		}
+		a.relayPool.SetTokenFile(tokenFile)
+	}
 	proxyMode := a.relayProxyMode(ctx)
 	a.relayPool.SetProxyMode(proxyMode)
-	a.log.Info("relay proxy configured", "wgPort", wgPort, "proxyMode", proxyMode)
+	a.log.Info("relay proxy configured", "wgPort", wgPort, "proxyMode", proxyMode, "transport", relayTransport)
 
 	// Inject relay transport into the WG engine BEFORE Connect so that even
 	// if the initial dial fails, the Bind is wired up and ready when the
@@ -1664,6 +1678,73 @@ func (a *Agent) initRelay(ctx context.Context, mesh *wirekubev1alpha1.WireKubeMe
 
 	a.log.Info("relay connected", "endpoint", endpoint, "mode", a.relayMode)
 	return nil
+}
+
+type relayDialConfig struct {
+	endpoint      string
+	probeAddr     string
+	transport     string
+	tokenRequired bool
+}
+
+func externalRelayDialConfig(external *wirekubev1alpha1.ExternalRelaySpec) (relayDialConfig, error) {
+	if external == nil || strings.TrimSpace(external.Endpoint) == "" {
+		return relayDialConfig{}, fmt.Errorf("external relay endpoint not configured")
+	}
+
+	transport := strings.ToLower(strings.TrimSpace(external.Transport))
+	if transport == "" {
+		transport = "tcp"
+	}
+	config := relayDialConfig{probeAddr: external.Endpoint, transport: transport}
+
+	switch transport {
+	case "tcp":
+		config.endpoint = external.Endpoint
+		if external.ControlEndpoint != "" {
+			config.endpoint = external.ControlEndpoint
+		}
+		if websocketScheme(config.endpoint) != "" {
+			return relayDialConfig{}, fmt.Errorf("relay transport tcp cannot use WebSocket controlEndpoint %q", config.endpoint)
+		}
+		host, port, err := net.SplitHostPort(config.endpoint)
+		if err != nil {
+			return relayDialConfig{}, fmt.Errorf("relay transport tcp requires a host:port endpoint, got %q: %w", config.endpoint, err)
+		}
+		if host == "" {
+			return relayDialConfig{}, fmt.Errorf("relay transport tcp endpoint %q has no host", config.endpoint)
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || portNumber < 1 || portNumber > 65535 {
+			return relayDialConfig{}, fmt.Errorf("relay transport tcp endpoint %q has an invalid port", config.endpoint)
+		}
+		return config, nil
+	case "ws", "wss":
+		if strings.TrimSpace(external.ControlEndpoint) == "" {
+			return relayDialConfig{}, fmt.Errorf("relay transport %s requires external.controlEndpoint", transport)
+		}
+		if scheme := websocketScheme(external.ControlEndpoint); scheme != transport {
+			return relayDialConfig{}, fmt.Errorf("relay transport %s requires a %s:// controlEndpoint, got %q", transport, transport, external.ControlEndpoint)
+		}
+		config.endpoint = external.ControlEndpoint
+		config.tokenRequired = true
+		return config, nil
+	default:
+		return relayDialConfig{}, fmt.Errorf("unsupported relay transport %q", external.Transport)
+	}
+}
+
+func websocketScheme(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "ws", "wss":
+		return strings.ToLower(parsed.Scheme)
+	default:
+		return ""
+	}
 }
 
 func (a *Agent) relayProxyMode(ctx context.Context) agentrelay.ProxyMode {

--- a/pkg/agent/path_monitor.go
+++ b/pkg/agent/path_monitor.go
@@ -212,6 +212,33 @@ func (m *PathMonitor) Forget(peerName string) {
 	m.mu.Unlock()
 }
 
+// ForceRelay makes relay the authoritative path without permanently disabling
+// future direct probes. Callers may invoke it on every sync while an external
+// policy such as relay.mode=always is active.
+func (m *PathMonitor) ForceRelay(peerName, pubKey string) PathMode {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	lastDirect := m.rx.LastDirectReceive(pubKey)
+	e, ok := m.entries[peerName]
+	if !ok {
+		e = &pathEntry{
+			modeEnteredAt: now,
+		}
+		m.entries[peerName] = e
+	}
+	e.pubKey = pubKey
+	e.lastDirectSeen = lastDirect
+	e.lastProbeAt = now
+	if e.mode != PathModeRelay {
+		prev := e.mode
+		e.setMode(PathModeRelay, now)
+		m.log.Info("path monitor: relay forced", "peer", peerName, "from", prev)
+	}
+	return e.mode
+}
+
 // MarkNeverDirect pins a peer to PathModeRelay and suppresses subsequent
 // Relay→Warm probes. Call when the agent has determined direct connectivity
 // is impossible for this peer (e.g. symmetric ↔ symmetric NAT pair with

--- a/pkg/agent/path_monitor_test.go
+++ b/pkg/agent/path_monitor_test.go
@@ -177,6 +177,36 @@ func TestForgetClearsEntry(t *testing.T) {
 	}
 }
 
+func TestForceRelayOverridesDirectWithoutDisablingFutureProbes(t *testing.T) {
+	pm, rx, clk := newMonitor(t)
+	pm.Evaluate("p1", "key1", true)
+	clk.advance(10 * time.Millisecond)
+	rx.last["key1"] = clk.now().UnixNano()
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeDirect {
+		t.Fatalf("setup: want Direct, got %v", got)
+	}
+
+	if got := pm.ForceRelay("p1", "key1"); got != PathModeRelay {
+		t.Fatalf("ForceRelay from Direct = %v, want PathModeRelay", got)
+	}
+	if got := pm.ModeFor("p1"); got != PathModeRelay {
+		t.Fatalf("ModeFor after ForceRelay = %v, want PathModeRelay", got)
+	}
+
+	clk.advance(100 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeRelay {
+		t.Fatalf("Evaluate before relay retry = %v, want PathModeRelay", got)
+	}
+	clk.advance(150 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("Evaluate after relay retry = %v, want PathModeWarm", got)
+	}
+	clk.advance(10 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("stale direct watermark after ForceRelay = %v, want PathModeWarm", got)
+	}
+}
+
 // TestStaleWatermarkIsNotFreshEvidence asserts that an RX watermark
 // captured before the peer entered Warm (e.g. from a previous Direct
 // session whose evidence the monitor already consumed) does not promote.

--- a/pkg/agent/relay/client.go
+++ b/pkg/agent/relay/client.go
@@ -48,6 +48,7 @@ type Client struct {
 	wgPort    int
 	proxyMode ProxyMode
 	proxyURL  *url.URL
+	tokenFile string
 
 	mu      sync.RWMutex
 	conn    net.Conn
@@ -85,6 +86,12 @@ func (c *Client) SetProxyURL(proxyURL *url.URL) {
 	defer c.mu.Unlock()
 	c.proxyMode = ProxyExplicit
 	c.proxyURL = proxyURL
+}
+
+func (c *Client) SetTokenFile(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tokenFile = path
 }
 
 // IsConnected returns whether the relay TCP connection is alive.
@@ -125,8 +132,9 @@ func (c *Client) dial(ctx context.Context) error {
 	c.mu.RLock()
 	proxyMode := c.proxyMode
 	proxyURL := c.proxyURL
+	tokenFile := c.tokenFile
 	c.mu.RUnlock()
-	conn, err := dialRelay(ctx, &dialer, c.relayAddr, proxyMode, proxyURL)
+	conn, err := dialRelay(ctx, &dialer, c.relayAddr, proxyMode, proxyURL, tokenFile)
 	if err != nil {
 		return fmt.Errorf("connecting to relay %s: %w", c.relayAddr, err)
 	}

--- a/pkg/agent/relay/dial.go
+++ b/pkg/agent/relay/dial.go
@@ -9,9 +9,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"golang.org/x/net/http/httpproxy"
+
+	relayproto "github.com/wirekube/wirekube/pkg/relay"
 )
 
 var relayProxyFromEnvironment = proxyURLFromEnvironment
@@ -35,7 +40,10 @@ func (m ProxyMode) normalized() ProxyMode {
 	}
 }
 
-func dialRelay(ctx context.Context, dialer *net.Dialer, relayAddr string, mode ProxyMode, explicitProxyURL *url.URL) (net.Conn, error) {
+func dialRelay(ctx context.Context, dialer *net.Dialer, relayAddr string, mode ProxyMode, explicitProxyURL *url.URL, tokenFile string) (net.Conn, error) {
+	if strings.HasPrefix(relayAddr, "ws://") || strings.HasPrefix(relayAddr, "wss://") {
+		return dialRelayWebSocket(ctx, dialer, relayAddr, mode, explicitProxyURL, tokenFile)
+	}
 	switch mode.normalized() {
 	case ProxyDisabled:
 		return dialer.DialContext(ctx, "tcp", relayAddr)
@@ -54,6 +62,42 @@ func dialRelay(ctx context.Context, dialer *net.Dialer, relayAddr string, mode P
 		}
 		return dialRelayViaHTTPProxy(ctx, dialer, relayAddr, proxyURL)
 	}
+}
+
+func dialRelayWebSocket(ctx context.Context, dialer *net.Dialer, relayURL string, mode ProxyMode, explicitProxyURL *url.URL, tokenFile string) (net.Conn, error) {
+	tokenBytes, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading relay token %q: %w", tokenFile, err)
+	}
+	token := strings.TrimSpace(string(tokenBytes))
+	if token == "" {
+		return nil, fmt.Errorf("relay token %q is empty", tokenFile)
+	}
+
+	wsDialer := websocket.Dialer{
+		NetDialContext:   dialer.DialContext,
+		HandshakeTimeout: dialTimeout,
+		Subprotocols:     []string{"wirekube.relay.v1"},
+	}
+	switch mode.normalized() {
+	case ProxyFromEnvironment:
+		wsDialer.Proxy = http.ProxyFromEnvironment
+	case ProxyExplicit:
+		if explicitProxyURL == nil {
+			return nil, fmt.Errorf("explicit relay proxy mode requires a proxy URL")
+		}
+		wsDialer.Proxy = func(*http.Request) (*url.URL, error) { return explicitProxyURL, nil }
+	}
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+token)
+	conn, resp, err := wsDialer.DialContext(ctx, relayURL, header)
+	if err != nil {
+		if resp != nil {
+			return nil, fmt.Errorf("WebSocket relay %s: %s: %w", relayURL, resp.Status, err)
+		}
+		return nil, fmt.Errorf("WebSocket relay %s: %w", relayURL, err)
+	}
+	return relayproto.NewWebSocketConn(conn), nil
 }
 
 func proxyURLFromEnvironment(relayAddr string) (*url.URL, error) {

--- a/pkg/agent/relay/pool.go
+++ b/pkg/agent/relay/pool.go
@@ -25,6 +25,8 @@ type Pool struct {
 	wgPort    int
 	proxyMode ProxyMode
 	proxyURL  *url.URL
+	tokenFile string
+	probeAddr string
 
 	mu      sync.RWMutex
 	clients map[string]*Client // keyed by resolved IP:port
@@ -89,6 +91,21 @@ func (p *Pool) SetProxyURL(proxyURL *url.URL) {
 	for _, c := range p.clients {
 		c.SetProxyURL(proxyURL)
 	}
+}
+
+func (p *Pool) SetTokenFile(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tokenFile = path
+	for _, c := range p.clients {
+		c.SetTokenFile(path)
+	}
+}
+
+func (p *Pool) SetProbeAddr(addr string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.probeAddr = addr
 }
 
 // Connect resolves the relay address and connects to all discovered endpoints.
@@ -241,6 +258,12 @@ func (p *Pool) SendNATProbe(ip net.IP, port int) error {
 func (p *Pool) RelayIP() string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
+	if p.probeAddr != "" {
+		host, _, err := net.SplitHostPort(p.probeAddr)
+		if err == nil {
+			return host
+		}
+	}
 	for addr := range p.clients {
 		host, _, err := net.SplitHostPort(addr)
 		if err == nil {
@@ -411,6 +434,7 @@ func (p *Pool) connectOne(ctx context.Context, addr string) error {
 	p.mu.RLock()
 	proxyMode := p.proxyMode
 	proxyURL := p.proxyURL
+	tokenFile := p.tokenFile
 	p.mu.RUnlock()
 
 	c := NewClient(addr, p.myPubKey, p.wgPort)
@@ -419,6 +443,7 @@ func (p *Pool) connectOne(ctx context.Context, addr string) error {
 	} else {
 		c.SetProxyMode(proxyMode)
 	}
+	c.SetTokenFile(tokenFile)
 	c.onData = p.handleData
 	c.onExternal = p.handleExternalData
 	c.onHint = p.handleHint
@@ -445,6 +470,9 @@ func (p *Pool) connectOne(ctx context.Context, addr string) error {
 // only return private RFC-1918 IPs — if the resolved IPs are all public, the
 // caller falls back to the raw hostname (a single connection).
 func (p *Pool) resolve() []string {
+	if parsed, err := url.Parse(p.relayAddr); err == nil && (parsed.Scheme == "ws" || parsed.Scheme == "wss") {
+		return nil
+	}
 	host, port, err := net.SplitHostPort(p.relayAddr)
 	if err != nil {
 		return nil

--- a/pkg/agent/relay_transport_test.go
+++ b/pkg/agent/relay_transport_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"testing"
+
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+)
+
+func TestExternalRelayDialConfigDefaultsToTCP(t *testing.T) {
+	config, err := externalRelayDialConfig(&wirekubev1alpha1.ExternalRelaySpec{
+		Endpoint:        "relay.example.com:3478",
+		ControlEndpoint: "relay-control.example.com:443",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.transport != "tcp" || config.endpoint != "relay-control.example.com:443" || config.probeAddr != "relay.example.com:3478" || config.tokenRequired {
+		t.Fatalf("unexpected config: %+v", config)
+	}
+}
+
+func TestExternalRelayDialConfigSelectsWSSFromMesh(t *testing.T) {
+	config, err := externalRelayDialConfig(&wirekubev1alpha1.ExternalRelaySpec{
+		Endpoint:        "203.0.113.10:3478",
+		ControlEndpoint: "wss://relay.example.com/relay",
+		Transport:       "wss",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.transport != "wss" || config.endpoint != "wss://relay.example.com/relay" || config.probeAddr != "203.0.113.10:3478" || !config.tokenRequired {
+		t.Fatalf("unexpected config: %+v", config)
+	}
+}
+
+func TestExternalRelayDialConfigRejectsTransportEndpointMismatch(t *testing.T) {
+	tests := []wirekubev1alpha1.ExternalRelaySpec{
+		{Endpoint: "203.0.113.10:3478", ControlEndpoint: "wss://relay.example.com/relay", Transport: "tcp"},
+		{Endpoint: "203.0.113.10:3478", ControlEndpoint: "https://relay.example.com/relay", Transport: "tcp"},
+		{Endpoint: "203.0.113.10:3478", ControlEndpoint: "ws://relay.example.com/relay", Transport: "wss"},
+		{Endpoint: "203.0.113.10:3478", Transport: "wss"},
+	}
+	for _, external := range tests {
+		if _, err := externalRelayDialConfig(&external); err == nil {
+			t.Fatalf("expected config to fail: %+v", external)
+		}
+	}
+}

--- a/pkg/api/v1alpha1/wirekubemesh_types.go
+++ b/pkg/api/v1alpha1/wirekubemesh_types.go
@@ -161,14 +161,16 @@ type ExternalRelaySpec struct {
 	// Example: "relay.example.com:3478" or "203.0.113.10:3478"
 	Endpoint string `json:"endpoint"`
 
-	// ControlEndpoint is reserved for legacy relay control operations. Shared
-	// external peers use Endpoint directly and do not require this field.
+	// ControlEndpoint is the agent-facing relay endpoint. It is required for
+	// ws/wss transport and may hold a separate raw TCP address for tcp transport.
+	// External WireGuard peers continue to use Endpoint.
 	// +optional
 	ControlEndpoint string `json:"controlEndpoint,omitempty"`
 
-	// Transport is the protocol used to connect to the relay.
+	// Transport selects the single protocol agents use to connect to the relay.
+	// Agents do not open tcp and WebSocket sessions at the same time.
 	// +kubebuilder:default=tcp
-	// +kubebuilder:validation:Enum=tcp;ws
+	// +kubebuilder:validation:Enum=tcp;ws;wss
 	Transport string `json:"transport,omitempty"`
 
 	// AuthSecretRef references a Kubernetes Secret containing the relay auth key.

--- a/pkg/relay/wsconn.go
+++ b/pkg/relay/wsconn.go
@@ -1,0 +1,71 @@
+package relay
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// WebSocketConn adapts binary WebSocket messages to the byte-stream contract
+// used by the relay framing protocol.
+type WebSocketConn struct {
+	conn *websocket.Conn
+
+	readMu  sync.Mutex
+	reader  io.Reader
+	writeMu sync.Mutex
+}
+
+func NewWebSocketConn(conn *websocket.Conn) *WebSocketConn {
+	return &WebSocketConn{conn: conn}
+}
+
+func (c *WebSocketConn) Read(p []byte) (int, error) {
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+
+	for {
+		if c.reader != nil {
+			n, err := c.reader.Read(p)
+			if err == nil {
+				return n, nil
+			}
+			if err != io.EOF {
+				return n, err
+			}
+			c.reader = nil
+			if n > 0 {
+				return n, nil
+			}
+		}
+
+		messageType, reader, err := c.conn.NextReader()
+		if err != nil {
+			return 0, err
+		}
+		if messageType != websocket.BinaryMessage {
+			continue
+		}
+		c.reader = reader
+	}
+}
+
+func (c *WebSocketConn) Write(p []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if err := c.conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *WebSocketConn) Close() error                       { return c.conn.Close() }
+func (c *WebSocketConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+func (c *WebSocketConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *WebSocketConn) SetDeadline(t time.Time) error      { return c.conn.UnderlyingConn().SetDeadline(t) }
+func (c *WebSocketConn) SetReadDeadline(t time.Time) error  { return c.conn.SetReadDeadline(t) }
+func (c *WebSocketConn) SetWriteDeadline(t time.Time) error { return c.conn.SetWriteDeadline(t) }

--- a/pkg/relay/wsgateway/auth.go
+++ b/pkg/relay/wsgateway/auth.go
@@ -1,0 +1,130 @@
+package wsgateway
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	relayproto "github.com/wirekube/wirekube/pkg/relay"
+)
+
+const serviceAccountUsernamePrefix = "system:serviceaccount:"
+
+type Authenticator struct {
+	TokenReviews             kubernetes.Interface
+	Client                   client.Client
+	Audience                 string
+	AgentServiceAccount      string
+	PeerServiceAccountPrefix string
+}
+
+func (a *Authenticator) Authenticate(ctx context.Context, token string) ([relayproto.PubKeySize]byte, string, error) {
+	var zero [relayproto.PubKeySize]byte
+	if token == "" {
+		return zero, "", fmt.Errorf("bearer token is empty")
+	}
+
+	review, err := a.TokenReviews.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{Token: token, Audiences: []string{a.Audience}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return zero, "", fmt.Errorf("TokenReview: %w", err)
+	}
+	if !review.Status.Authenticated {
+		return zero, "", fmt.Errorf("token was not authenticated: %s", review.Status.Error)
+	}
+	if !contains(review.Status.Audiences, a.Audience) {
+		return zero, "", fmt.Errorf("token audience %q was not accepted", a.Audience)
+	}
+
+	namespace, serviceAccount, err := parseServiceAccountUsername(review.Status.User.Username)
+	if err != nil {
+		return zero, "", err
+	}
+	peerName, err := a.peerForIdentity(ctx, namespace, serviceAccount, review.Status.User.Extra)
+	if err != nil {
+		return zero, "", err
+	}
+
+	peer := &wirekubev1alpha1.WireKubePeer{}
+	if err := a.Client.Get(ctx, client.ObjectKey{Name: peerName}, peer); err != nil {
+		return zero, "", fmt.Errorf("get WireKubePeer %q: %w", peerName, err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(peer.Spec.PublicKey)
+	if err != nil || len(decoded) != relayproto.PubKeySize {
+		return zero, "", fmt.Errorf("WireKubePeer %q has an invalid public key", peerName)
+	}
+	var expected [relayproto.PubKeySize]byte
+	copy(expected[:], decoded)
+	return expected, peerName, nil
+}
+
+func (a *Authenticator) peerForIdentity(ctx context.Context, namespace, serviceAccount string, extra map[string]authenticationv1.ExtraValue) (string, error) {
+	identity := namespace + "/" + serviceAccount
+	if identity == a.AgentServiceAccount {
+		podName := firstExtra(extra, "authentication.kubernetes.io/pod-name")
+		podUID := firstExtra(extra, "authentication.kubernetes.io/pod-uid")
+		if podName == "" || podUID == "" {
+			return "", fmt.Errorf("agent token is not bound to a Pod")
+		}
+		pod := &corev1.Pod{}
+		if err := a.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: podName}, pod); err != nil {
+			return "", fmt.Errorf("get bound Pod %s/%s: %w", namespace, podName, err)
+		}
+		if string(pod.UID) != podUID {
+			return "", fmt.Errorf("bound Pod UID does not match")
+		}
+		if pod.Spec.ServiceAccountName != serviceAccount {
+			return "", fmt.Errorf("bound Pod service account does not match")
+		}
+		if pod.Spec.NodeName == "" {
+			return "", fmt.Errorf("bound Pod is not scheduled")
+		}
+		return pod.Spec.NodeName, nil
+	}
+
+	if a.PeerServiceAccountPrefix != "" && strings.HasPrefix(serviceAccount, a.PeerServiceAccountPrefix) {
+		peerName := strings.TrimPrefix(serviceAccount, a.PeerServiceAccountPrefix)
+		if peerName == "" {
+			return "", fmt.Errorf("peer service account has no peer suffix")
+		}
+		return peerName, nil
+	}
+	return "", fmt.Errorf("service account %s is not allowed", identity)
+}
+
+func parseServiceAccountUsername(username string) (string, string, error) {
+	if !strings.HasPrefix(username, serviceAccountUsernamePrefix) {
+		return "", "", fmt.Errorf("identity %q is not a Kubernetes ServiceAccount", username)
+	}
+	parts := strings.Split(strings.TrimPrefix(username, serviceAccountUsernamePrefix), ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid ServiceAccount identity %q", username)
+	}
+	return parts[0], parts[1], nil
+}
+
+func firstExtra(extra map[string]authenticationv1.ExtraValue, key string) string {
+	values := extra[key]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/relay/wsgateway/auth_test.go
+++ b/pkg/relay/wsgateway/auth_test.go
@@ -1,0 +1,108 @@
+package wsgateway
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+)
+
+func TestAuthenticatePodBoundAgent(t *testing.T) {
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "wirekube-system", Name: "agent-worker2", UID: types.UID("pod-uid")},
+		Spec:       corev1.PodSpec{ServiceAccountName: "wirekube-agent", NodeName: "worker2"},
+	}
+	peer := &wirekubev1alpha1.WireKubePeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker2"},
+		Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: base64.StdEncoding.EncodeToString(key)},
+	}
+	auth := testAuthenticator(t, pod, peer)
+	auth.TokenReviews.(*fake.Clientset).PrependReactor("create", "tokenreviews", tokenReviewReactor(authenticationv1.UserInfo{
+		Username: "system:serviceaccount:wirekube-system:wirekube-agent",
+		Extra: map[string]authenticationv1.ExtraValue{
+			"authentication.kubernetes.io/pod-name": {"agent-worker2"},
+			"authentication.kubernetes.io/pod-uid":  {"pod-uid"},
+		},
+	}))
+
+	got, peerName, err := auth.Authenticate(context.Background(), "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if peerName != "worker2" || string(got[:]) != string(key) {
+		t.Fatalf("got peer=%q key=%x", peerName, got)
+	}
+}
+
+func TestAuthenticateDedicatedPeerServiceAccount(t *testing.T) {
+	key := make([]byte, 32)
+	peer := &wirekubev1alpha1.WireKubePeer{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker7"},
+		Spec:       wirekubev1alpha1.WireKubePeerSpec{PublicKey: base64.StdEncoding.EncodeToString(key)},
+	}
+	auth := testAuthenticator(t, peer)
+	auth.TokenReviews.(*fake.Clientset).PrependReactor("create", "tokenreviews", tokenReviewReactor(authenticationv1.UserInfo{
+		Username: "system:serviceaccount:wirekube-system:wirekube-relay-peer-worker7",
+	}))
+
+	_, peerName, err := auth.Authenticate(context.Background(), "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if peerName != "worker7" {
+		t.Fatalf("peerName=%q", peerName)
+	}
+}
+
+func TestAuthenticateRejectsUnboundSharedAgentToken(t *testing.T) {
+	auth := testAuthenticator(t)
+	auth.TokenReviews.(*fake.Clientset).PrependReactor("create", "tokenreviews", tokenReviewReactor(authenticationv1.UserInfo{
+		Username: "system:serviceaccount:wirekube-system:wirekube-agent",
+	}))
+
+	if _, _, err := auth.Authenticate(context.Background(), "token"); err == nil {
+		t.Fatal("expected unbound agent token to be rejected")
+	}
+}
+
+func testAuthenticator(t *testing.T, objects ...runtime.Object) *Authenticator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := wirekubev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return &Authenticator{
+		TokenReviews:             fake.NewSimpleClientset(),
+		Client:                   controllerfake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build(),
+		Audience:                 "wirekube-relay",
+		AgentServiceAccount:      "wirekube-system/wirekube-agent",
+		PeerServiceAccountPrefix: "wirekube-relay-peer-",
+	}
+}
+
+func tokenReviewReactor(user authenticationv1.UserInfo) clientgotesting.ReactionFunc {
+	return func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		review := action.(clientgotesting.CreateAction).GetObject().(*authenticationv1.TokenReview).DeepCopy()
+		review.Status.Authenticated = true
+		review.Status.Audiences = []string{"wirekube-relay"}
+		review.Status.User = user
+		return true, review, nil
+	}
+}

--- a/pkg/relay/wsgateway/server.go
+++ b/pkg/relay/wsgateway/server.go
@@ -1,0 +1,164 @@
+package wsgateway
+
+import (
+	"bufio"
+	"context"
+	"crypto/subtle"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	relayproto "github.com/wirekube/wirekube/pkg/relay"
+)
+
+type Server struct {
+	Authenticator *Authenticator
+	BackendAddr   string
+	Path          string
+	Dialer        net.Dialer
+	Upgrader      websocket.Upgrader
+}
+
+func NewServer(authenticator *Authenticator, backendAddr, path string) *Server {
+	return &Server{
+		Authenticator: authenticator,
+		BackendAddr:   backendAddr,
+		Path:          path,
+		Dialer:        net.Dialer{Timeout: 10 * time.Second},
+		Upgrader: websocket.Upgrader{
+			Subprotocols: []string{"wirekube.relay.v1"},
+			CheckOrigin: func(r *http.Request) bool {
+				return r.Header.Get("Origin") == ""
+			},
+		},
+	}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/readyz", s.handleReady)
+	mux.HandleFunc(s.Path, s.handleRelay)
+	return mux
+}
+
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+	defer cancel()
+	backend, err := s.Dialer.DialContext(ctx, "tcp", s.BackendAddr)
+	if err != nil {
+		http.Error(w, "relay backend unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	_ = backend.Close()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) handleRelay(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token, ok := bearerToken(r.Header.Get("Authorization"))
+	if !ok {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	expectedKey, peerName, err := s.Authenticator.Authenticate(r.Context(), token)
+	if err != nil {
+		log.Printf("relay-ws: authentication rejected: %v", err)
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	ws, err := s.Upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	ws.SetReadLimit(2 * relayproto.MaxFrameSize)
+	conn := relayproto.NewWebSocketConn(ws)
+	defer conn.Close()
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return
+	}
+
+	reader := bufio.NewReader(conn)
+	frame, err := relayproto.ReadFrame(reader)
+	if err != nil {
+		log.Printf("relay-ws: %s register read failed: %v", peerName, err)
+		return
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return
+	}
+	if frame.Type != relayproto.MsgRegister || len(frame.Body) != relayproto.PubKeySize || subtle.ConstantTimeCompare(frame.Body, expectedKey[:]) != 1 {
+		log.Printf("relay-ws: %s public key binding rejected", peerName)
+		_ = ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "public key does not match token identity"), time.Now().Add(time.Second))
+		return
+	}
+
+	backend, err := s.Dialer.DialContext(r.Context(), "tcp", s.BackendAddr)
+	if err != nil {
+		log.Printf("relay-ws: %s backend dial failed: %v", peerName, err)
+		return
+	}
+	defer backend.Close()
+	if err := relayproto.WriteFrame(backend, frame); err != nil {
+		log.Printf("relay-ws: %s backend register failed: %v", peerName, err)
+		return
+	}
+
+	log.Printf("relay-ws: peer connected: %s", peerName)
+	errCh := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(backend, reader)
+		errCh <- err
+	}()
+	go func() {
+		_, err := io.Copy(conn, backend)
+		errCh <- err
+	}()
+	select {
+	case <-r.Context().Done():
+	case <-errCh:
+	}
+	log.Printf("relay-ws: peer disconnected: %s", peerName)
+}
+
+func bearerToken(header string) (string, bool) {
+	scheme, token, ok := strings.Cut(header, " ")
+	if !ok || !strings.EqualFold(scheme, "Bearer") || strings.TrimSpace(token) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(token), true
+}
+
+func ListenAndServe(ctx context.Context, addr string, handler http.Handler, certFile, keyFile string) error {
+	if (certFile == "") != (keyFile == "") {
+		return fmt.Errorf("relay-ws TLS certificate and private key must be configured together")
+	}
+	server := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	var err error
+	if certFile != "" {
+		err = server.ListenAndServeTLS(certFile, keyFile)
+	} else {
+		err = server.ListenAndServe()
+	}
+	if err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("relay-ws listen: %w", err)
+	}
+	return nil
+}

--- a/pkg/relay/wsgateway/server_test.go
+++ b/pkg/relay/wsgateway/server_test.go
@@ -1,0 +1,37 @@
+package wsgateway
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListenAndServeRequiresTLSCertificateAndKey(t *testing.T) {
+	if err := ListenAndServe(context.Background(), "127.0.0.1:0", http.NewServeMux(), "cert.pem", ""); err == nil {
+		t.Fatal("expected incomplete TLS configuration to fail")
+	}
+}
+
+func TestReadyChecksRawRelayBackend(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	server := NewServer(nil, listener.Addr().String(), "/relay")
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("ready status=%d", recorder.Code)
+	}
+
+	listener.Close()
+	recorder = httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unready status=%d", recorder.Code)
+	}
+}

--- a/test/kind_e2e/infra_test.go
+++ b/test/kind_e2e/infra_test.go
@@ -5,8 +5,15 @@ package kind_e2e
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"os"
 	"os/exec"
@@ -17,6 +24,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -295,9 +304,9 @@ func enforceVPCIsolation() error {
 			}
 		}
 
-		// Allow API server and relay (OUTPUT from workers, INPUT on CP)
+		// Allow API server and relay entrypoints (OUTPUT from workers, INPUT on CP)
 		if self.name != cp.name {
-			for _, port := range []int{6443, 3478} {
+			for _, port := range []int{6443, 3478, 8443} {
 				if _, err := ctrExec("exec", self.name, "iptables", "-A", "OUTPUT",
 					"-d", cp.ip, "-p", "tcp", "--dport", fmt.Sprintf("%d", port), "-j", "ACCEPT"); err != nil {
 					return fmt.Errorf("allow tcp/%d on %s: %w", port, self.name, err)
@@ -325,6 +334,7 @@ func enforceVPCIsolation() error {
 				}{
 					{"tcp", 6443},
 					{"tcp", 3478},
+					{"tcp", 8443},
 					{"udp", stunPort1},
 					{"udp", stunPort2},
 				} {
@@ -1117,15 +1127,21 @@ func deployWireKubeCRDs(_ context.Context) error {
 	return nil
 }
 
-func deployWireKubeAgents(_ context.Context) error {
+func deployWireKubeAgents(ctx context.Context) error {
 	image := wireKubeImage()
 
-	if err := applyDaemonSet(image); err != nil {
-		return fmt.Errorf("apply DaemonSet: %w", err)
+	if relayTransport() == relayTransportWSS {
+		if err := ensureRelayTLSSecret(ctx); err != nil {
+			return fmt.Errorf("prepare relay TLS: %w", err)
+		}
 	}
 
 	if err := deployRelay(image); err != nil {
 		return fmt.Errorf("deploy relay: %w", err)
+	}
+
+	if err := applyDaemonSet(image); err != nil {
+		return fmt.Errorf("apply DaemonSet: %w", err)
 	}
 
 	return nil
@@ -1149,6 +1165,14 @@ func applyDaemonSet(image string) error {
 		}
 	}
 	content = strings.Join(lines, "\n")
+	if relayTransport() == relayTransportWSS {
+		content = strings.Replace(content,
+			"          volumeMounts:\n",
+			"          volumeMounts:\n            - name: relay-e2e-ca\n              mountPath: /etc/ssl/certs/wirekube-relay-e2e-ca.pem\n              subPath: wirekube-relay-e2e-ca.pem\n              readOnly: true\n", 1)
+		content = strings.Replace(content,
+			"      volumes:\n",
+			"      volumes:\n        - name: relay-e2e-ca\n          secret:\n            secretName: wirekube-relay-e2e-tls\n            items:\n              - key: tls.crt\n                path: wirekube-relay-e2e-ca.pem\n", 1)
+	}
 
 	// Inject direct API server address. Required for no-kube-proxy mode
 	// (Cilium kube-proxy replacement) and also avoids conntrack issues
@@ -1228,6 +1252,177 @@ spec:
 	}
 	tmp.Close()
 
+	if err := kubectlApply(tmp.Name()); err != nil {
+		return err
+	}
+	if relayTransport() == relayTransportWSS {
+		return deployWebSocketRelay(image)
+	}
+	return nil
+}
+
+func ensureRelayTLSSecret(ctx context.Context) error {
+	certPEM, keyPEM, err := relayTLSCertificate()
+	if err != nil {
+		return err
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay-e2e-tls", Namespace: agentNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+	existing := &corev1.Secret{}
+	key := client.ObjectKeyFromObject(secret)
+	if err := k8sClient.Get(ctx, key, existing); apierrors.IsNotFound(err) {
+		return k8sClient.Create(ctx, secret)
+	} else if err != nil {
+		return err
+	}
+	patch := client.MergeFrom(existing.DeepCopy())
+	existing.Type = secret.Type
+	existing.Data = secret.Data
+	return k8sClient.Patch(ctx, existing, patch)
+}
+
+func relayTLSCertificate() ([]byte, []byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: "wirekube-relay-e2e"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		IPAddresses:           []net.IP{net.ParseIP(cpNode().ip)},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM, nil
+}
+
+func deployWebSocketRelay(image string) error {
+	yaml := fmt.Sprintf(`---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wirekube-relay
+  namespace: %[1]s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wirekube-relay-e2e
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["wirekube.io"]
+    resources: ["wirekubepeers"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wirekube-relay-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wirekube-relay-e2e
+subjects:
+  - kind: ServiceAccount
+    name: wirekube-relay
+    namespace: %[1]s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wirekube-relay-ws
+  namespace: %[1]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wirekube-relay-ws
+  template:
+    metadata:
+      labels:
+        app: wirekube-relay-ws
+    spec:
+      serviceAccountName: wirekube-relay
+      hostNetwork: true
+      dnsPolicy: Default
+      tolerations:
+        - operator: Exists
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+      containers:
+        - name: relay-ws
+          image: %[2]s
+          command: ["wirekube-relay-ws"]
+          args:
+            - --addr=:8443
+            - --backend-addr=127.0.0.1:3478
+            - --path=/relay
+            - --tls-cert-file=/var/run/wirekube-relay-tls/tls.crt
+            - --tls-private-key-file=/var/run/wirekube-relay-tls/tls.key
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /readyz
+              port: 8443
+            initialDelaySeconds: 2
+            periodSeconds: 2
+          volumeMounts:
+            - name: relay-tls
+              mountPath: /var/run/wirekube-relay-tls
+              readOnly: true
+      volumes:
+        - name: relay-tls
+          secret:
+            secretName: wirekube-relay-e2e-tls
+`, agentNamespace, image)
+
+	tmp, err := os.CreateTemp("", "wk-relay-wss-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.WriteString(yaml); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
 	return kubectlApply(tmp.Name())
 }
 
@@ -1241,10 +1436,13 @@ func applyWireKubeMeshCR(ctx context.Context, stunServers []string, relayEndpoin
 		Provider: "external",
 		External: &wirekubev1alpha1.ExternalRelaySpec{
 			Endpoint:  relayEndpoint,
-			Transport: "tcp",
+			Transport: relayTransport(),
 		},
 		HandshakeTimeoutSeconds:    15,
 		DirectRetryIntervalSeconds: 30,
+	}
+	if relayTransport() == relayTransportWSS {
+		mesh.Spec.Relay.External.ControlEndpoint = fmt.Sprintf("wss://%s:8443/relay", cpNode().ip)
 	}
 	mesh.Spec.NATTraversal = &wirekubev1alpha1.NATTraversalSpec{
 		HandshakeValidWindowSeconds:  10,

--- a/test/kind_e2e/infra_test.go
+++ b/test/kind_e2e/infra_test.go
@@ -1395,6 +1395,11 @@ spec:
             - --path=/relay
             - --tls-cert-file=/var/run/wirekube-relay-tls/tls.crt
             - --tls-private-key-file=/var/run/wirekube-relay-tls/tls.key
+          env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: "%[3]s"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
           readinessProbe:
             httpGet:
               scheme: HTTPS
@@ -1410,7 +1415,7 @@ spec:
         - name: relay-tls
           secret:
             secretName: wirekube-relay-e2e-tls
-`, agentNamespace, image)
+`, agentNamespace, image, cpNode().ip)
 
 	tmp, err := os.CreateTemp("", "wk-relay-wss-*.yaml")
 	if err != nil {
@@ -1718,40 +1723,5 @@ func patchMeshRelayMode(ctx context.Context, t *testing.T, newMode string) func(
 		if err := k8sClient.Patch(rctx, &m, p); err != nil {
 			t.Logf("warning: restore relay.mode=%q: %v", originalMode, err)
 		}
-	}
-}
-
-func relayEndpointFromMesh(ctx context.Context, t *testing.T) string {
-	t.Helper()
-	var mesh wirekubev1alpha1.WireKubeMesh
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName}, &mesh); err != nil {
-		t.Fatalf("get WireKubeMesh: %v", err)
-	}
-	if mesh.Spec.Relay != nil && mesh.Spec.Relay.External != nil {
-		return mesh.Spec.Relay.External.Endpoint
-	}
-	return ""
-}
-
-func setRelayEndpoint(ctx context.Context, t *testing.T, endpoint string) {
-	t.Helper()
-	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	var mesh wirekubev1alpha1.WireKubeMesh
-	if err := k8sClient.Get(tctx, types.NamespacedName{Name: meshName}, &mesh); err != nil {
-		t.Logf("warning: get WireKubeMesh: %v", err)
-		return
-	}
-	p := client.MergeFrom(mesh.DeepCopy())
-	if mesh.Spec.Relay == nil {
-		mesh.Spec.Relay = &wirekubev1alpha1.RelaySpec{}
-	}
-	if mesh.Spec.Relay.External == nil {
-		mesh.Spec.Relay.External = &wirekubev1alpha1.ExternalRelaySpec{}
-	}
-	mesh.Spec.Relay.External.Endpoint = endpoint
-	if err := k8sClient.Patch(tctx, &mesh, p); err != nil {
-		t.Logf("warning: patch relay endpoint to %s: %v", endpoint, err)
 	}
 }

--- a/test/kind_e2e/suite_test.go
+++ b/test/kind_e2e/suite_test.go
@@ -35,6 +35,7 @@
 //	WIREKUBE_E2E_REUSE=1        skip teardown for faster re-runs
 //	WIREKUBE_E2E_SKIP_SETUP=1   skip cluster creation (assume running)
 //	WIREKUBE_E2E_CNI_MODE       "cilium-kube-proxy" (default), "cilium-no-kube-proxy", "flannel", or "calico"
+//	WIREKUBE_E2E_RELAY_TRANSPORT "tcp" (default) or "wss"
 package kind_e2e
 
 import (
@@ -74,6 +75,9 @@ const (
 	cniModeNoKubeProxyVxlan = "cilium-no-kube-proxy"
 	cniModeFlannel          = "flannel"
 	cniModeCalico           = "calico"
+
+	relayTransportTCP = "tcp"
+	relayTransportWSS = "wss"
 )
 
 type nodeConfig struct {
@@ -171,6 +175,13 @@ func cniMode() string {
 	return cniModeKubeProxyVxlan
 }
 
+func relayTransport() string {
+	if transport := os.Getenv("WIREKUBE_E2E_RELAY_TRANSPORT"); transport != "" {
+		return transport
+	}
+	return relayTransportTCP
+}
+
 func skipKubeProxy() bool {
 	return cniMode() == cniModeNoKubeProxyVxlan
 }
@@ -187,6 +198,12 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 	code := 1
 	defer func() { os.Exit(code) }()
+
+	if transport := relayTransport(); transport != relayTransportTCP && transport != relayTransportWSS {
+		fmt.Fprintf(os.Stderr, "e2e: unsupported relay transport %q\n", transport)
+		return
+	}
+	fmt.Printf("e2e: relay transport=%s\n", relayTransport())
 
 	if err := os.Chdir(repoRoot()); err != nil {
 		fmt.Fprintf(os.Stderr, "e2e: chdir: %v\n", err)

--- a/test/kind_e2e/transport_test.go
+++ b/test/kind_e2e/transport_test.go
@@ -9,11 +9,46 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
 )
+
+func TestRelayTransportConfigured(t *testing.T) {
+	ctx := context.Background()
+	var mesh wirekubev1alpha1.WireKubeMesh
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName}, &mesh); err != nil {
+		t.Fatalf("get WireKubeMesh: %v", err)
+	}
+	if mesh.Spec.Relay == nil || mesh.Spec.Relay.External == nil {
+		t.Fatal("external relay is not configured")
+	}
+	external := mesh.Spec.Relay.External
+	if external.Transport != relayTransport() {
+		t.Fatalf("relay transport=%q, want %q", external.Transport, relayTransport())
+	}
+	if relayTransport() == relayTransportTCP {
+		if external.ControlEndpoint != "" {
+			t.Fatalf("TCP control endpoint=%q, want empty", external.ControlEndpoint)
+		}
+		return
+	}
+
+	expectedEndpoint := fmt.Sprintf("wss://%s:8443/relay", cpNode().ip)
+	if external.ControlEndpoint != expectedEndpoint {
+		t.Fatalf("WSS control endpoint=%q, want %q", external.ControlEndpoint, expectedEndpoint)
+	}
+	eventually(t, func() bool {
+		var deployment appsv1.Deployment
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentNamespace, Name: "wirekube-relay-ws"}, &deployment); err != nil {
+			t.Logf("get WSS relay deployment: %v", err)
+			return false
+		}
+		return deployment.Status.ReadyReplicas == 1
+	}, 2*time.Minute, pollInterval, "WSS relay gateway should be ready")
+}
 
 func resetTransportState(ctx context.Context, t *testing.T) []string {
 	t.Helper()

--- a/test/kind_e2e/transport_test.go
+++ b/test/kind_e2e/transport_test.go
@@ -746,6 +746,8 @@ func TestRelayReconnect(t *testing.T) {
 	restoreMode := patchMeshRelayMode(ctx, t, "always")
 	defer restoreMode()
 	waitForRelayDataPlane(ctx, t, subject, remote, relayTimeout)
+	unblock := blockWireGuardUDP(t, subject)
+	defer unblock()
 
 	restoreEntrypoint := scaleRelayEntrypoint(ctx, t, 0)
 	defer restoreEntrypoint()

--- a/test/kind_e2e/transport_test.go
+++ b/test/kind_e2e/transport_test.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
 )
@@ -48,6 +49,86 @@ func TestRelayTransportConfigured(t *testing.T) {
 		}
 		return deployment.Status.ReadyReplicas == 1
 	}, 2*time.Minute, pollInterval, "WSS relay gateway should be ready")
+
+	peers := waitForPeers(ctx, t, len(nodeConfigs))
+	restoreMode := patchMeshRelayMode(ctx, t, "always")
+	defer restoreMode()
+	waitForRelayDataPlane(ctx, t, peers[0], peers[1], relayTimeout)
+}
+
+func waitForRelayDataPlane(ctx context.Context, t *testing.T, subject, remote string, timeout time.Duration) {
+	t.Helper()
+	remoteIP := nodeIPForPeer(t, remote)
+
+	eventually(t, func() bool {
+		mode := connectionMode(ctx, t, subject, remote)
+		if mode != "relay" {
+			t.Logf("%s → %s = %q, waiting for relay", subject, remote, mode)
+			return false
+		}
+
+		pod := agentPodForNode(ctx, t, subject)
+		out, err := execInPod(ctx, t, pod, "agent", []string{"ping", "-c", "2", "-W", "2", remoteIP})
+		if err != nil {
+			t.Logf("relay ping %s→%s: %v (%s)", subject, remote, err, out)
+			return false
+		}
+		t.Logf("relay data plane %s→%s is healthy", subject, remote)
+		return true
+	}, timeout, pollInterval, subject+" → "+remote+" should pass traffic over relay")
+}
+
+func relayEntrypointDeployment() string {
+	if relayTransport() == relayTransportWSS {
+		return "wirekube-relay-ws"
+	}
+	return "wirekube-relay"
+}
+
+func scaleRelayEntrypoint(ctx context.Context, t *testing.T, replicas int32) func() {
+	t.Helper()
+	name := relayEntrypointDeployment()
+	key := types.NamespacedName{Namespace: agentNamespace, Name: name}
+
+	var deployment appsv1.Deployment
+	if err := k8sClient.Get(ctx, key, &deployment); err != nil {
+		t.Fatalf("get relay entrypoint deployment %s: %v", name, err)
+	}
+	originalReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		originalReplicas = *deployment.Spec.Replicas
+	}
+
+	setReplicas := func(value int32) error {
+		var current appsv1.Deployment
+		if err := k8sClient.Get(ctx, key, &current); err != nil {
+			return err
+		}
+		patch := client.MergeFrom(current.DeepCopy())
+		current.Spec.Replicas = &value
+		return k8sClient.Patch(ctx, &current, patch)
+	}
+	if err := setReplicas(replicas); err != nil {
+		t.Fatalf("scale relay entrypoint deployment %s to %d: %v", name, replicas, err)
+	}
+
+	eventually(t, func() bool {
+		var current appsv1.Deployment
+		if err := k8sClient.Get(ctx, key, &current); err != nil {
+			t.Logf("get relay entrypoint deployment %s: %v", name, err)
+			return false
+		}
+		if replicas == 0 {
+			return current.Status.Replicas == 0
+		}
+		return current.Status.ReadyReplicas == replicas
+	}, 2*time.Minute, pollInterval, fmt.Sprintf("relay entrypoint deployment %s should have %d ready replicas", name, replicas))
+
+	return func() {
+		if err := setReplicas(originalReplicas); err != nil {
+			t.Logf("warning: restore relay entrypoint deployment %s to %d replicas: %v", name, originalReplicas, err)
+		}
+	}
 }
 
 func resetTransportState(ctx context.Context, t *testing.T) []string {
@@ -664,29 +745,25 @@ func TestRelayReconnect(t *testing.T) {
 
 	restoreMode := patchMeshRelayMode(ctx, t, "always")
 	defer restoreMode()
+	waitForRelayDataPlane(ctx, t, subject, remote, relayTimeout)
 
-	eventually(t, func() bool {
-		return connectionMode(ctx, t, subject, remote) == "relay"
-	}, relayTimeout, pollInterval, subject+" → "+remote+" should be relay")
-
-	original := relayEndpointFromMesh(ctx, t)
-	if original == "" {
-		t.Skip("no external relay endpoint")
-	}
-
-	setRelayEndpoint(ctx, t, "127.0.0.1:19999")
-	defer setRelayEndpoint(ctx, t, original)
+	restoreEntrypoint := scaleRelayEntrypoint(ctx, t, 0)
+	defer restoreEntrypoint()
 
 	t.Log("relay broken — waiting 15s…")
 	time.Sleep(15 * time.Second)
 
-	setRelayEndpoint(ctx, t, original)
-
+	restoreEntrypoint()
 	eventually(t, func() bool {
-		mode := connectionMode(ctx, t, subject, remote)
-		t.Logf("%s → %s = %q", subject, remote, mode)
-		return mode == "relay" || mode == "direct"
-	}, 3*time.Minute, pollInterval, "should recover after relay restore")
+		var deployment appsv1.Deployment
+		name := relayEntrypointDeployment()
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentNamespace, Name: name}, &deployment); err != nil {
+			t.Logf("get relay entrypoint deployment %s: %v", name, err)
+			return false
+		}
+		return deployment.Status.ReadyReplicas == 1
+	}, 2*time.Minute, pollInterval, "relay entrypoint should become ready after restore")
+	waitForRelayDataPlane(ctx, t, subject, remote, 3*time.Minute)
 	t.Log("relay reconnect recovery confirmed")
 
 	restoreMode()


### PR DESCRIPTION
## What changed

- add authenticated WebSocket relay transport with `ws` and `wss` endpoint selection from `WireKubeMesh`
- bind Kubernetes ServiceAccount tokens to the connecting peer public key through TokenReview and Pod identity checks
- add WSS gateway, NodePort, and external relay examples with updated relay entrypoint documentation
- run kind E2E coverage for both `tcp` and `wss` across every supported CNI mode

## Why

Some clusters cannot expose or reach a raw TCP relay endpoint, while HTTPS load balancers and outbound proxies are commonly available. WSS provides a TLS-protected relay entrypoint without changing the WireKube relay protocol or allowing concurrent TCP and WebSocket sessions for the same agent.

## Impact

TCP remains the default transport. Users can select WSS through `spec.relay.external.transport` and `controlEndpoint`; agents authenticate with a projected Pod-bound ServiceAccount token. Existing external WireGuard peers continue to use the raw relay endpoint.

## Validation

- `go mod tidy`
- `go vet ./...`
- `go test $(go list ./... | rg -v '/test/e2e$') -count=1`
- `go test -c -tags kind_e2e -o /tmp/wirekube-kind-e2e.test ./test/kind_e2e`
- YAML parsing for `config/**/*.yaml` and `.github/workflows/*.yml`
- GitHub Actions matrix: TCP and WSS for Cilium, Cilium without kube-proxy, Flannel, and Calico
