### PR TITLE
feat(cli): add safe installation lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,63 +1,202 @@
-name: Build and Push Image
+name: Release
 
 on:
   push:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
-  REGISTRY: docker.io
   IMAGE_NAME: inerplat/wirekube
+  E2E_IMAGE: inerplat/wirekube:release-${{ github.sha }}
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Check module files
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+      - name: Check formatting
+        run: |
+          files=$(gofmt -l .)
+          test -z "$files" || { echo "$files"; exit 1; }
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.1
+
+      - name: Unit tests
+        run: go test $(go list ./... | grep -v /test/e2e) -count=1
+
+      - name: Build commands
+        run: |
+          CGO_ENABLED=0 go build ./cmd/agent ./cmd/relay ./cmd/relay-ws ./cmd/wirekubectl
+          for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
+            os=${target%/*}
+            arch=${target#*/}
+            CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -o /tmp/wirekubectl-$os-$arch ./cmd/wirekubectl
+          done
+
+  build-e2e-image:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build test image
+        run: docker build -t ${{ env.E2E_IMAGE }} .
+
+      - name: Save test image
+        run: docker save ${{ env.E2E_IMAGE }} -o /tmp/wirekube-release-e2e.tar
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wirekube-release-e2e-image
+          path: /tmp/wirekube-release-e2e.tar
+          retention-days: 1
+
+  e2e:
+    needs: build-e2e-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        cni-mode: [cilium-kube-proxy, cilium-no-kube-proxy, flannel, calico]
+        relay-transport: [tcp, wss]
+        include:
+          - cni-mode: cilium-kube-proxy
+            need-helm: true
+          - cni-mode: cilium-no-kube-proxy
+            need-helm: true
+          - cni-mode: flannel
+            need-helm: false
+          - cni-mode: calico
+            need-helm: false
+    name: e2e (${{ matrix.cni-mode }}, ${{ matrix.relay-transport }})
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
+
+      - name: Install helm
+        if: matrix.need-helm
+        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - run: docker pull kindest/node:v1.34.0
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: wirekube-release-e2e-image
+          path: /tmp
+
+      - run: docker load -i /tmp/wirekube-release-e2e.tar
+
+      - name: Run E2E
+        run: |
+          WIREKUBE_IMAGE=${{ env.E2E_IMAGE }} \
+          WIREKUBE_E2E_CNI_MODE=${{ matrix.cni-mode }} \
+          WIREKUBE_E2E_RELAY_TRANSPORT=${{ matrix.relay-transport }} \
+          go test -tags kind_e2e -v ./test/kind_e2e/... -timeout 20m
+
+  publish-image:
+    needs: e2e
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract tag
-        id: meta
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
+      - id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
             ${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  test:
+  release-cli:
+    needs: publish-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - name: Vet
-        run: go vet ./...
+      - name: Build wirekubectl release assets
+        env:
+          VERSION: ${{ github.ref_name }}
+          COMMIT: ${{ github.sha }}
+          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+        run: |
+          build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          ldflags="-s -w -X github.com/inerplat/wirekube/internal/version.Version=${VERSION} -X github.com/inerplat/wirekube/internal/version.Commit=${COMMIT} -X github.com/inerplat/wirekube/internal/version.BuildDate=${build_date} -X github.com/inerplat/wirekube/internal/version.DefaultImage=${IMAGE_NAME}@${IMAGE_DIGEST}"
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$ldflags" -o dist/wirekubectl-darwin-arm64 ./cmd/wirekubectl
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$ldflags" -o dist/wirekubectl-darwin-amd64 ./cmd/wirekubectl
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$ldflags" -o dist/wirekubectl-linux-amd64 ./cmd/wirekubectl
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$ldflags" -o dist/wirekubectl-linux-arm64 ./cmd/wirekubectl
+          python3 - <<PY
+          import json
+          from pathlib import Path
+          Path("dist/wirekube-release.json").write_text(json.dumps({
+              "schemaVersion": "v1alpha1",
+              "version": "${VERSION}",
+              "commit": "${COMMIT}",
+              "buildDate": "${build_date}",
+              "image": "${IMAGE_NAME}@${IMAGE_DIGEST}",
+          }, indent=2) + "\n")
+          PY
+          cd dist
+          sha256sum wirekubectl-* wirekube-release.json > wirekubectl-checksums.txt
 
-      - name: Test
-        run: go test $(go list ./... | grep -v /test/e2e) -v
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/wirekubectl-darwin-arm64
+            dist/wirekubectl-darwin-amd64
+            dist/wirekubectl-linux-amd64
+            dist/wirekubectl-linux-arm64
+            dist/wirekubectl-checksums.txt
+            dist/wirekube-release.json

--- a/README.md
+++ b/README.md
@@ -45,20 +45,15 @@ No coordination server, no external etcd, no control plane beyond the Kubernetes
 ## Quick Start
 
 ```bash
-# 1. Install CRDs and create default mesh configuration
-kubectl apply -f config/crd/
-kubectl apply -f config/examples/wirekubemesh-basic.yaml
-
-# 2. Create the namespace, RBAC, and agent DaemonSet
-kubectl create namespace wirekube-system --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f config/agent/rbac.yaml
-kubectl apply -f config/agent/daemonset.yaml
-
-# 3. Verify
-kubectl get wirekubepeers -o wide
+# Download a wirekubectl binary from the GitHub Release for your platform,
+# verify it with wirekubectl-checksums.txt, and place it on PATH.
+wirekubectl install --kubeconfig ~/.kube/config --context my-cluster
+wirekubectl status
 ```
 
-Each agent auto-discovers its endpoint and registers as a WireKubePeer. Set `meshCIDR` on the `WireKubeMesh` CR and every peer is automatically assigned a deterministic `/32` overlay IP from that range (derived from the node name):
+The installer inspects the cluster and shows the exact CRDs, privileged workloads, relay infrastructure, image digest, and mesh CIDR before mutation. Automation must select the relay topology and mesh CIDR explicitly, for example `wirekubectl install --relay load-balancer --mesh-cidr 100.96.0.0/11 --yes --output json`.
+
+Each agent auto-discovers its endpoint and registers as a WireKubePeer. Every peer receives a deterministic `/32` overlay IP from the selected mesh CIDR:
 
 ```yaml
 apiVersion: wirekube.io/v1alpha1
@@ -101,7 +96,7 @@ See the [Quick Start guide](https://inerplat.github.io/wirekube/getting-started/
 |-----------|---------|---------|
 | **Agent** | DaemonSet (`hostNetwork: true`) | Manages WireGuard interface, discovers endpoints, syncs peers, handles relay failover |
 | **Relay** | Deployment + Service | Bridges WireGuard UDP over TCP when NAT blocks direct P2P |
-| **wirekubectl** | CLI | Status inspection and peer management |
+| **wirekubectl** | CLI | Installation lifecycle, status inspection, diagnostics, and peer management |
 | **Admin web** | Relay sidecar | Manages external peers through the Kubernetes API |
 
 For details on NAT traversal, routing design, and the relay protocol, see the [Architecture documentation](https://inerplat.github.io/wirekube/architecture/overview/).

--- a/cmd/admin-web/main.go
+++ b/cmd/admin-web/main.go
@@ -35,9 +35,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/externalpeer"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/externalpeer"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 const (

--- a/cmd/admin-web/main_test.go
+++ b/cmd/admin-web/main_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestIssuePeerCreatesCRAndReturnsConfig(t *testing.T) {

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,10 +24,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	agentpkg "github.com/wirekube/wirekube/pkg/agent"
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	externalctrl "github.com/wirekube/wirekube/pkg/controller/external"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	agentpkg "github.com/inerplat/wirekube/pkg/agent"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	externalctrl "github.com/inerplat/wirekube/pkg/controller/external"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 var scheme = runtime.NewScheme()
@@ -248,10 +248,14 @@ func relayControlAddrFromMesh(mesh *wirekubev1alpha1.WireKubeMesh, _ string) str
 }
 
 func relayPublicHostFromService(ctx context.Context, c client.Reader, namespace string) string {
-	svc := &corev1.Service{}
-	if err := c.Get(ctx, client.ObjectKey{Name: "wirekube-relay", Namespace: namespace}, svc); err != nil {
+	udpService := &corev1.Service{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "wirekube-relay-udp", Namespace: namespace}, udpService); err != nil {
 		return ""
 	}
+	return loadBalancerHost(udpService)
+}
+
+func loadBalancerHost(svc *corev1.Service) string {
 	for _, ip := range svc.Spec.ExternalIPs {
 		if ip != "" {
 			return ip

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestRelayControlAddrFromMeshPrefersControlEndpoint(t *testing.T) {
@@ -80,7 +80,7 @@ func TestRelayControlAddrFromMeshManagedDoesNotEnableControlByDefault(t *testing
 	}
 }
 
-func TestRelayEndpointFromMeshManagedUsesLoadBalancerHost(t *testing.T) {
+func TestRelayEndpointFromMeshManagedDoesNotUseTCPServiceAsUDPEndpoint(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(&corev1.Service{
@@ -103,9 +103,47 @@ func TestRelayEndpointFromMeshManagedUsesLoadBalancerHost(t *testing.T) {
 		},
 	}
 
+	if got := relayEndpointFromMesh(context.Background(), c, mesh, "wirekube-system"); got != "" {
+		t.Fatalf("relayEndpointFromMesh = %q, want empty without a UDP Service", got)
+	}
+}
+
+func TestRelayEndpointFromMeshManagedPrefersSeparateUDPService(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay", Namespace: "wirekube-system"},
+				Status:     corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{Hostname: "tcp-relay.example.com"}}}},
+			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay-udp", Namespace: "wirekube-system"},
+				Status:     corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{Hostname: "udp-relay.example.com"}}}},
+			},
+		).
+		Build()
+	mesh := &wirekubev1alpha1.WireKubeMesh{Spec: wirekubev1alpha1.WireKubeMeshSpec{Relay: &wirekubev1alpha1.RelaySpec{Managed: &wirekubev1alpha1.ManagedRelaySpec{Port: 3478}}}}
+
 	got := relayEndpointFromMesh(context.Background(), c, mesh, "wirekube-system")
-	want := "relay.example.com:3478"
-	if got != want {
-		t.Fatalf("relayEndpointFromMesh = %q, want %q", got, want)
+	if got != "udp-relay.example.com:3478" {
+		t.Fatalf("relayEndpointFromMesh = %q", got)
+	}
+}
+
+func TestRelayEndpointFromMeshManagedWaitsForSeparateUDPService(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay", Namespace: "wirekube-system"},
+				Status:     corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{{Hostname: "tcp-relay.example.com"}}}},
+			},
+			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay-udp", Namespace: "wirekube-system"}},
+		).
+		Build()
+	mesh := &wirekubev1alpha1.WireKubeMesh{Spec: wirekubev1alpha1.WireKubeMeshSpec{Relay: &wirekubev1alpha1.RelaySpec{Managed: &wirekubev1alpha1.ManagedRelaySpec{Port: 3478}}}}
+
+	if got := relayEndpointFromMesh(context.Background(), c, mesh, "wirekube-system"); got != "" {
+		t.Fatalf("relayEndpointFromMesh = %q, want empty while UDP LoadBalancer is pending", got)
 	}
 }

--- a/cmd/relay-ws/main.go
+++ b/cmd/relay-ws/main.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/relay/wsgateway"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/relay/wsgateway"
 )
 
 func main() {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/wirekube/wirekube/pkg/relay"
+	"github.com/inerplat/wirekube/pkg/relay"
 )
 
 func main() {

--- a/cmd/wirekubectl/lifecycle.go
+++ b/cmd/wirekubectl/lifecycle.go
@@ -1,0 +1,709 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	internalinstall "github.com/inerplat/wirekube/internal/install"
+	internalconfig "github.com/inerplat/wirekube/internal/kubeconfig"
+	internalversion "github.com/inerplat/wirekube/internal/version"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+)
+
+type lifecycleFlags struct {
+	relay            string
+	relayEndpoint    string
+	relayUDPEndpoint string
+	relayUDP         bool
+	meshCIDR         string
+	nodeAddresses    string
+	image            string
+	excludeCIDRs     []string
+	yes              bool
+	dryRun           bool
+	adopt            bool
+}
+
+type componentStatus struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Ready     bool   `json:"ready"`
+	Desired   int32  `json:"desired,omitempty"`
+	Available int32  `json:"available,omitempty"`
+	Message   string `json:"message"`
+}
+
+type installationStatus struct {
+	SchemaVersion     string            `json:"schemaVersion"`
+	InstallationID    string            `json:"installationID"`
+	WireKubeVersion   string            `json:"wireKubeVersion"`
+	Image             string            `json:"image"`
+	Ready             bool              `json:"ready"`
+	ComponentsReady   bool              `json:"componentsReady"`
+	ConnectivityReady bool              `json:"connectivityReady"`
+	Components        []componentStatus `json:"components"`
+	UpdatedAt         time.Time         `json:"updatedAt"`
+}
+
+type doctorCheck struct {
+	Name    string `json:"name"`
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+type doctorOutput struct {
+	SchemaVersion string              `json:"schemaVersion"`
+	Ready         bool                `json:"ready"`
+	Checks        []doctorCheck       `json:"checks"`
+	Installation  *installationStatus `json:"installation,omitempty"`
+}
+
+func installCmd() *cobra.Command {
+	flags := &lifecycleFlags{}
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Plan and install WireKube without a source checkout",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if options.output == "json" && !flags.yes && !flags.dryRun {
+				return fmt.Errorf("--output=json requires --yes or --dry-run")
+			}
+			plan, normalized, installer, err := buildInstallationPlan(cmd, flags)
+			if err != nil {
+				return err
+			}
+			if flags.dryRun {
+				return writePlan(cmd.OutOrStdout(), plan)
+			}
+			if options.output == "text" {
+				writePlanText(cmd.OutOrStdout(), plan)
+				if !flags.yes {
+					confirmed, err := confirm(cmd.InOrStdin(), cmd.OutOrStdout(), "Install? [y/N] ")
+					if err != nil {
+						return err
+					}
+					if !confirmed {
+						return fmt.Errorf("installation cancelled")
+					}
+				}
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), options.timeout)
+			defer cancel()
+			result, err := installer.Apply(ctx, plan, normalized, "install")
+			if err != nil {
+				return err
+			}
+			return writeLifecycleResult(cmd, result)
+		},
+	}
+	addLifecycleFlags(cmd, flags)
+	return cmd
+}
+
+func upgradeCmd() *cobra.Command {
+	flags := &lifecycleFlags{}
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade resources owned by an existing wirekubectl installation",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if options.output == "json" && !flags.yes && !flags.dryRun {
+				return fmt.Errorf("--output=json requires --yes or --dry-run")
+			}
+			factory := kubeFactory()
+			c, err := factory.Client()
+			if err != nil {
+				return err
+			}
+			installer := internalinstall.Installer{Client: c}
+			inventory, err := installer.LoadInventory(cmd.Context(), options.namespace)
+			if err != nil {
+				return fmt.Errorf("load existing installation: %w", err)
+			}
+			applyStoredLifecycleDefaults(cmd, flags, inventory.Options)
+			plan, normalized, _, err := buildInstallationPlanWithClient(cmd, flags, c, factory, installer)
+			if err != nil {
+				return err
+			}
+			if flags.dryRun {
+				return writePlan(cmd.OutOrStdout(), plan)
+			}
+			if options.output == "text" && !flags.yes {
+				writePlanText(cmd.OutOrStdout(), plan)
+				confirmed, err := confirm(cmd.InOrStdin(), cmd.OutOrStdout(), "Upgrade? [y/N] ")
+				if err != nil || !confirmed {
+					if err != nil {
+						return err
+					}
+					return fmt.Errorf("upgrade cancelled")
+				}
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), options.timeout)
+			defer cancel()
+			result, err := installer.Apply(ctx, plan, normalized, "upgrade")
+			if err != nil {
+				return err
+			}
+			return writeLifecycleResult(cmd, result)
+		},
+	}
+	addLifecycleFlags(cmd, flags)
+	return cmd
+}
+
+func manifestCmd() *cobra.Command {
+	flags := &lifecycleFlags{}
+	cmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Render the exact installation resources without applying them",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			plan, normalized, _, err := buildInstallationPlan(cmd, flags)
+			if err != nil {
+				return err
+			}
+			bundle, err := internalinstall.Render(normalized)
+			if err != nil {
+				return err
+			}
+			if options.output == "json" {
+				resources := make([]any, 0, len(bundle.CRDs)+len(bundle.Objects))
+				for _, crd := range bundle.CRDs {
+					resources = append(resources, crd)
+				}
+				for _, object := range bundle.Objects {
+					resources = append(resources, object)
+				}
+				return writeJSON(cmd.OutOrStdout(), map[string]any{"schemaVersion": internalinstall.SchemaVersion, "plan": plan, "resources": resources})
+			}
+			data, err := internalinstall.Manifest(bundle)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		},
+	}
+	addLifecycleFlags(cmd, flags)
+	return cmd
+}
+
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show installation inventory and workload readiness",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, err := kubeFactory().Client()
+			if err != nil {
+				return err
+			}
+			inventory, err := (internalinstall.Installer{Client: c}).LoadInventory(cmd.Context(), options.namespace)
+			if err != nil {
+				return fmt.Errorf("load installation inventory: %w", err)
+			}
+			status := inspectInstallation(cmd.Context(), c, inventory)
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), status)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Installation: %s\nVersion:      %s\nImage:        %s\nUpdated:      %s\nComponents:   %t\nConnectivity: %t\nReady:        %t\n", status.InstallationID, status.WireKubeVersion, status.Image, status.UpdatedAt.Format(time.RFC3339), status.ComponentsReady, status.ConnectivityReady, status.Ready)
+			for _, component := range status.Components {
+				state := "NOT READY"
+				if component.Ready {
+					state = "READY"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%-10s %-9s %s\n", component.Name, state, component.Message)
+			}
+			return nil
+		},
+	}
+}
+
+func doctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Inspect common installation and readiness failures",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			factory := kubeFactory()
+			result := doctorOutput{SchemaVersion: internalinstall.SchemaVersion, Ready: true}
+			add := func(name string, ok bool, message string) {
+				result.Checks = append(result.Checks, doctorCheck{Name: name, OK: ok, Message: message})
+				result.Ready = result.Ready && ok
+			}
+			if discovery, err := factory.Discovery(); err != nil {
+				add("api", false, err.Error())
+			} else if version, err := discovery.ServerVersion(); err != nil {
+				add("api", false, err.Error())
+			} else {
+				add("api", true, version.GitVersion)
+			}
+			c, err := factory.Client()
+			if err != nil {
+				add("client", false, err.Error())
+				return writeDoctorResult(cmd, result)
+			}
+			inventory, err := (internalinstall.Installer{Client: c}).LoadInventory(cmd.Context(), options.namespace)
+			add("inventory", err == nil, messageForError(err, "installation inventory found"))
+			if err == nil {
+				status := inspectInstallation(cmd.Context(), c, inventory)
+				result.Installation = &status
+				for _, component := range status.Components {
+					add(component.Name, component.Ready, component.Message)
+				}
+				owned, message := checkInventoryOwnership(cmd.Context(), c, inventory)
+				add("ownership", owned, message)
+				if inventory.Options.Relay != internalinstall.RelayNone {
+					reachable, message := checkRelayReachability(cmd.Context(), c, inventory)
+					add("relay-reachability", reachable, message)
+				}
+			}
+			return writeDoctorResult(cmd, result)
+		},
+	}
+}
+
+func inspectInstallation(ctx context.Context, c client.Client, inventory *internalinstall.Inventory) installationStatus {
+	status := installationStatus{
+		SchemaVersion:   internalinstall.SchemaVersion,
+		InstallationID:  inventory.InstallationID,
+		WireKubeVersion: inventory.WireKubeVersion,
+		Image:           inventory.Image,
+		ComponentsReady: true,
+		UpdatedAt:       inventory.UpdatedAt,
+	}
+	addComponent := func(component componentStatus) {
+		status.Components = append(status.Components, component)
+		status.ComponentsReady = status.ComponentsReady && component.Ready
+	}
+
+	crdTotal, crdEstablished := 0, 0
+	var crdFailures []string
+	for _, resource := range inventory.Resources {
+		if resource.Kind != "CustomResourceDefinition" {
+			continue
+		}
+		crdTotal++
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := c.Get(ctx, client.ObjectKey{Name: resource.Name}, crd); err != nil {
+			crdFailures = append(crdFailures, resource.Name+": "+messageForError(err, ""))
+			continue
+		}
+		for _, condition := range crd.Status.Conditions {
+			if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+				crdEstablished++
+				break
+			}
+		}
+	}
+	crdMessage := fmt.Sprintf("%d/%d established", crdEstablished, crdTotal)
+	if len(crdFailures) > 0 {
+		crdMessage += "; " + strings.Join(crdFailures, "; ")
+	}
+	addComponent(componentStatus{Name: "crds", Kind: "CustomResourceDefinition", Ready: crdTotal > 0 && crdEstablished == crdTotal, Desired: int32(crdTotal), Available: int32(crdEstablished), Message: crdMessage})
+
+	desiredAgents := int32(0)
+	daemonSet := &appsv1.DaemonSet{}
+	agentErr := c.Get(ctx, types.NamespacedName{Namespace: inventory.Options.Namespace, Name: "wirekube-agent"}, daemonSet)
+	agent := componentStatus{Name: "agent", Kind: "DaemonSet", Message: messageForError(agentErr, "")}
+	if agentErr == nil {
+		desiredAgents = daemonSet.Status.DesiredNumberScheduled
+		agent.Desired = desiredAgents
+		agent.Available = daemonSet.Status.NumberReady
+		agent.Ready = desiredAgents > 0 && daemonSet.Status.ObservedGeneration >= daemonSet.Generation && daemonSet.Status.UpdatedNumberScheduled == desiredAgents && daemonSet.Status.NumberReady == desiredAgents && daemonSet.Status.NumberAvailable == desiredAgents
+		agent.Message = fmt.Sprintf("%d/%d ready, %d updated", daemonSet.Status.NumberReady, desiredAgents, daemonSet.Status.UpdatedNumberScheduled)
+		if len(daemonSet.Spec.Template.Spec.Containers) == 0 || daemonSet.Spec.Template.Spec.Containers[0].Image != inventory.Image {
+			agent.Ready = false
+			actual := "missing"
+			if len(daemonSet.Spec.Template.Spec.Containers) > 0 {
+				actual = daemonSet.Spec.Template.Spec.Containers[0].Image
+			}
+			agent.Message += fmt.Sprintf("; image=%s, inventory=%s", actual, inventory.Image)
+		}
+	}
+	addComponent(agent)
+
+	mesh := &wirekubev1alpha1.WireKubeMesh{}
+	meshErr := c.Get(ctx, client.ObjectKey{Name: "default"}, mesh)
+	meshStatus := componentStatus{Name: "mesh", Kind: "WireKubeMesh", Message: messageForError(meshErr, "")}
+	if meshErr == nil {
+		meshStatus.Desired = desiredAgents
+		meshStatus.Available = mesh.Status.TotalPeers
+		meshStatus.Ready = desiredAgents > 0 && mesh.Status.TotalPeers >= desiredAgents && mesh.Status.ReadyPeers >= desiredAgents
+		meshStatus.Message = fmt.Sprintf("%d peers observed, %d ready", mesh.Status.TotalPeers, mesh.Status.ReadyPeers)
+		for _, condition := range mesh.Status.Conditions {
+			if condition.Status != metav1.ConditionTrue && condition.Message != "" {
+				meshStatus.Message += "; " + condition.Type + ": " + condition.Message
+			}
+		}
+	}
+	status.Components = append(status.Components, meshStatus)
+	status.ConnectivityReady = meshStatus.Ready
+
+	if inventory.Options.Relay == internalinstall.RelayLoadBalancer || inventory.Options.Relay == internalinstall.RelayNodePort {
+		deployment := &appsv1.Deployment{}
+		deploymentErr := c.Get(ctx, types.NamespacedName{Namespace: inventory.Options.Namespace, Name: "wirekube-relay"}, deployment)
+		relay := componentStatus{Name: "relay", Kind: "Deployment", Message: messageForError(deploymentErr, "")}
+		if deploymentErr == nil {
+			relay.Desired = 1
+			relay.Available = deployment.Status.ReadyReplicas
+			relay.Ready = deployment.Status.ObservedGeneration >= deployment.Generation && deployment.Status.UpdatedReplicas == 1 && deployment.Status.ReadyReplicas == 1 && deployment.Status.AvailableReplicas == 1
+			relay.Message = fmt.Sprintf("%d/1 ready, %d updated", deployment.Status.ReadyReplicas, deployment.Status.UpdatedReplicas)
+			if len(deployment.Spec.Template.Spec.Containers) == 0 || deployment.Spec.Template.Spec.Containers[0].Image != inventory.Image {
+				relay.Ready = false
+				actual := "missing"
+				if len(deployment.Spec.Template.Spec.Containers) > 0 {
+					actual = deployment.Spec.Template.Spec.Containers[0].Image
+				}
+				relay.Message += fmt.Sprintf("; image=%s, inventory=%s", actual, inventory.Image)
+			}
+		}
+		addComponent(relay)
+
+		addComponent(inspectRelayService(ctx, c, inventory.Options.Namespace, "wirekube-relay", "relay-entrypoint", inventory.Options.Relay, corev1.ProtocolTCP))
+		if inventory.Options.RelayUDP {
+			addComponent(inspectRelayService(ctx, c, inventory.Options.Namespace, "wirekube-relay-udp", "relay-udp-entrypoint", inventory.Options.Relay, corev1.ProtocolUDP))
+		}
+	} else if inventory.Options.Relay == internalinstall.RelayExternal {
+		endpoint := strings.TrimSpace(inventory.Options.RelayEndpoint)
+		addComponent(componentStatus{Name: "relay-entrypoint", Kind: "External", Ready: endpoint != "", Message: "external control endpoint " + endpoint})
+	}
+
+	status.Ready = status.ComponentsReady && status.ConnectivityReady
+	return status
+}
+
+func checkRelayReachability(ctx context.Context, c client.Client, inventory *internalinstall.Inventory) (bool, string) {
+	endpoint := strings.TrimSpace(inventory.Options.RelayEndpoint)
+	if inventory.Options.Relay == internalinstall.RelayLoadBalancer {
+		service := &corev1.Service{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: inventory.Options.Namespace, Name: "wirekube-relay"}, service); err != nil {
+			return false, messageForError(err, "")
+		}
+		host := ""
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if ingress.IP != "" {
+				host = ingress.IP
+				break
+			}
+			if ingress.Hostname != "" {
+				host = ingress.Hostname
+				break
+			}
+		}
+		port := int32(0)
+		for _, servicePort := range service.Spec.Ports {
+			if servicePort.Protocol == corev1.ProtocolTCP {
+				port = servicePort.Port
+				break
+			}
+		}
+		if host == "" || port == 0 {
+			return false, "relay TCP LoadBalancer endpoint is not assigned"
+		}
+		endpoint = net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	}
+	if endpoint == "" {
+		return false, "relay control endpoint is not configured"
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	connection, err := (&net.Dialer{}).DialContext(probeCtx, "tcp", endpoint)
+	if err != nil {
+		return false, fmt.Sprintf("TCP connect to %s failed: %v", endpoint, err)
+	}
+	_ = connection.Close()
+	return true, "TCP connect to " + endpoint + " succeeded"
+}
+
+func inspectRelayService(ctx context.Context, c client.Client, namespace, serviceName, componentName, relayMode string, protocol corev1.Protocol) componentStatus {
+	service := &corev1.Service{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: serviceName}, service)
+	entrypoint := componentStatus{Name: componentName, Kind: "Service", Message: messageForError(err, "")}
+	if err != nil {
+		return entrypoint
+	}
+	if relayMode == internalinstall.RelayLoadBalancer {
+		addresses := make([]string, 0, len(service.Status.LoadBalancer.Ingress))
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			if ingress.IP != "" {
+				addresses = append(addresses, ingress.IP)
+			} else if ingress.Hostname != "" {
+				addresses = append(addresses, ingress.Hostname)
+			}
+		}
+		entrypoint.Ready = len(addresses) > 0
+		entrypoint.Message = "LoadBalancer address pending"
+		if entrypoint.Ready {
+			entrypoint.Message = "LoadBalancer address " + strings.Join(addresses, ",")
+		}
+		return entrypoint
+	}
+	for _, port := range service.Spec.Ports {
+		if port.Protocol == protocol && port.NodePort > 0 {
+			entrypoint.Ready = true
+			entrypoint.Message = fmt.Sprintf("%s NodePort %d", protocol, port.NodePort)
+			return entrypoint
+		}
+	}
+	entrypoint.Message = fmt.Sprintf("%s NodePort is not assigned", protocol)
+	return entrypoint
+}
+
+func checkInventoryOwnership(ctx context.Context, c client.Client, inventory *internalinstall.Inventory) (bool, string) {
+	checked := 0
+	var failures []string
+	for _, resource := range inventory.Resources {
+		if resource.Kind == "Namespace" {
+			continue
+		}
+		checked++
+		object := &unstructured.Unstructured{}
+		object.SetAPIVersion(resource.APIVersion)
+		object.SetKind(resource.Kind)
+		err := c.Get(ctx, client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, object)
+		if err != nil {
+			failures = append(failures, resource.Kind+" "+resourceDisplayName(resource)+": "+messageForError(err, ""))
+			continue
+		}
+		if object.GetLabels()["app.kubernetes.io/managed-by"] != "wirekubectl" {
+			failures = append(failures, resource.Kind+" "+resourceDisplayName(resource)+": managed-by label is missing")
+		} else if object.GetLabels()[internalinstall.InstallationIDLabel] != inventory.InstallationID {
+			failures = append(failures, resource.Kind+" "+resourceDisplayName(resource)+": installation ID does not match inventory")
+		}
+	}
+	if len(failures) > 0 {
+		return false, strings.Join(failures, "; ")
+	}
+	return true, fmt.Sprintf("%d inventory resources are owned by wirekubectl", checked)
+}
+
+func resourceDisplayName(resource internalinstall.Resource) string {
+	if resource.Namespace == "" {
+		return resource.Name
+	}
+	return resource.Namespace + "/" + resource.Name
+}
+
+func writeDoctorResult(cmd *cobra.Command, result doctorOutput) error {
+	if options.output == "json" {
+		if err := writeJSON(cmd.OutOrStdout(), result); err != nil {
+			return err
+		}
+		if !result.Ready {
+			return fmt.Errorf("doctor found failed checks")
+		}
+		return nil
+	}
+	for _, check := range result.Checks {
+		state := "FAIL"
+		if check.OK {
+			state = "OK"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%-4s %-18s %s\n", state, check.Name, check.Message)
+	}
+	if !result.Ready {
+		return fmt.Errorf("doctor found failed checks")
+	}
+	return nil
+}
+
+func uninstallCmd() *cobra.Command {
+	var purge, confirmPurge, yes bool
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove managed workloads while preserving CRDs and custom resources",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if options.output == "json" && !yes {
+				return fmt.Errorf("--output=json requires --yes")
+			}
+			if purge && !confirmPurge {
+				return fmt.Errorf("--purge requires --confirm-purge; --yes does not imply destructive data deletion")
+			}
+			if !yes {
+				prompt := "Uninstall managed workloads? [y/N] "
+				if purge {
+					prompt = "Permanently delete WireKube CRDs and all custom resources? [y/N] "
+				}
+				confirmed, err := confirm(cmd.InOrStdin(), cmd.OutOrStdout(), prompt)
+				if err != nil || !confirmed {
+					if err != nil {
+						return err
+					}
+					return fmt.Errorf("uninstall cancelled")
+				}
+			}
+			c, err := kubeFactory().Client()
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), options.timeout)
+			defer cancel()
+			inventory, err := (internalinstall.Installer{Client: c}).Uninstall(ctx, options.namespace, purge)
+			if err != nil {
+				return err
+			}
+			return writeResult(cmd, map[string]any{"operation": "uninstall", "purged": purge, "installationID": inventory.InstallationID}, fmt.Sprintf("WireKube installation %s removed (purge=%t)\n", inventory.InstallationID, purge))
+		},
+	}
+	cmd.Flags().BoolVar(&purge, "purge", false, "also delete all WireKube custom resources and CRDs")
+	cmd.Flags().BoolVar(&confirmPurge, "confirm-purge", false, "explicitly authorize destructive CRD and custom-resource deletion")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the ordinary uninstall confirmation")
+	return cmd
+}
+
+func addLifecycleFlags(cmd *cobra.Command, flags *lifecycleFlags) {
+	cmd.Flags().StringVar(&flags.relay, "relay", "", "relay mode: none, load-balancer, node-port, or external")
+	cmd.Flags().StringVar(&flags.relayEndpoint, "relay-endpoint", "", "external or NodePort relay endpoint as HOST:PORT")
+	cmd.Flags().StringVar(&flags.relayUDPEndpoint, "relay-udp-endpoint", "", "raw WireGuard UDP endpoint for external peer invites as HOST:PORT")
+	cmd.Flags().BoolVar(&flags.relayUDP, "relay-udp", false, "create a separate UDP relay Service")
+	cmd.Flags().StringVar(&flags.meshCIDR, "mesh-cidr", "auto", "mesh CIDR or auto")
+	cmd.Flags().StringVar(&flags.nodeAddresses, "node-addresses", "mesh-only", "node address exposure: mesh-only or internal-ip")
+	cmd.Flags().StringVar(&flags.image, "image", internalversion.DefaultImage, "immutable WireKube image reference (IMAGE@sha256:DIGEST)")
+	cmd.Flags().StringSliceVar(&flags.excludeCIDRs, "exclude-cidr", nil, "CIDR that automatic mesh selection must avoid; may be repeated")
+	cmd.Flags().BoolVar(&flags.yes, "yes", false, "apply the displayed plan without prompting")
+	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "inspect and print the plan without mutating the cluster")
+	cmd.Flags().BoolVar(&flags.adopt, "adopt", false, "explicitly adopt conflicting existing resources")
+}
+
+func buildInstallationPlan(cmd *cobra.Command, flags *lifecycleFlags) (internalinstall.Plan, internalinstall.Options, internalinstall.Installer, error) {
+	factory := kubeFactory()
+	c, err := factory.Client()
+	if err != nil {
+		return internalinstall.Plan{}, internalinstall.Options{}, internalinstall.Installer{}, err
+	}
+	return buildInstallationPlanWithClient(cmd, flags, c, factory, internalinstall.Installer{Client: c})
+}
+
+func buildInstallationPlanWithClient(cmd *cobra.Command, flags *lifecycleFlags, c client.Client, factory *internalconfig.Factory, installer internalinstall.Installer) (internalinstall.Plan, internalinstall.Options, internalinstall.Installer, error) {
+	discovery, err := factory.Discovery()
+	if err != nil {
+		return internalinstall.Plan{}, internalinstall.Options{}, installer, err
+	}
+	contextName, server, err := targetCluster(factory)
+	if err != nil {
+		return internalinstall.Plan{}, internalinstall.Options{}, installer, err
+	}
+	installOptions := internalinstall.Options{
+		Namespace: options.namespace, Image: flags.image, Relay: flags.relay, RelayEndpoint: flags.relayEndpoint, RelayUDPEndpoint: flags.relayUDPEndpoint, RelayUDP: flags.relayUDP, MeshCIDR: flags.meshCIDR, NodeAddresses: flags.nodeAddresses, ExcludeCIDRs: flags.excludeCIDRs, Yes: flags.yes, DryRun: flags.dryRun, Adopt: flags.adopt, Timeout: options.timeout, Context: contextName, ClusterServer: server, WireKubeVersion: internalversion.Version,
+	}
+	plan, normalized, err := (internalinstall.Planner{Client: c, Discovery: discovery, AccessReviewer: internalinstall.SelfSubjectAccessReviewer{Client: c}}).Build(cmd.Context(), installOptions)
+	return plan, normalized, installer, err
+}
+
+func kubeFactory() *internalconfig.Factory {
+	return internalconfig.New(internalconfig.Options{Kubeconfig: options.kubeconfig, Context: options.context, Namespace: options.namespace, Timeout: options.timeout}, scheme)
+}
+
+func targetCluster(factory *internalconfig.Factory) (string, string, error) {
+	raw, err := factory.RawConfig()
+	if err != nil {
+		return "", "", err
+	}
+	contextName := options.context
+	if contextName == "" {
+		contextName = raw.CurrentContext
+	}
+	contextConfig := raw.Contexts[contextName]
+	if contextConfig == nil {
+		return "", "", fmt.Errorf("context %q does not exist", contextName)
+	}
+	cluster := raw.Clusters[contextConfig.Cluster]
+	if cluster == nil {
+		return "", "", fmt.Errorf("cluster %q referenced by context %q does not exist", contextConfig.Cluster, contextName)
+	}
+	return contextName, cluster.Server, nil
+}
+
+func applyStoredLifecycleDefaults(cmd *cobra.Command, flags *lifecycleFlags, stored internalinstall.Options) {
+	if !cmd.Flags().Changed("relay") {
+		flags.relay = stored.Relay
+	}
+	if !cmd.Flags().Changed("relay-endpoint") {
+		flags.relayEndpoint = stored.RelayEndpoint
+	}
+	if !cmd.Flags().Changed("relay-udp-endpoint") {
+		flags.relayUDPEndpoint = stored.RelayUDPEndpoint
+	}
+	if !cmd.Flags().Changed("relay-udp") {
+		flags.relayUDP = stored.RelayUDP
+	}
+	if !cmd.Flags().Changed("mesh-cidr") {
+		flags.meshCIDR = stored.MeshCIDR
+	}
+	if !cmd.Flags().Changed("node-addresses") {
+		flags.nodeAddresses = stored.NodeAddresses
+	}
+	if !cmd.Flags().Changed("image") && strings.TrimSpace(flags.image) == "" {
+		flags.image = stored.Image
+	}
+}
+
+func writePlan(out io.Writer, plan internalinstall.Plan) error {
+	if options.output == "json" {
+		return writeJSON(out, plan)
+	}
+	writePlanText(out, plan)
+	return nil
+}
+
+func writePlanText(out io.Writer, plan internalinstall.Plan) {
+	fmt.Fprintln(out, "WireKube installation plan")
+	fmt.Fprintf(out, "\nCluster\n  Context:       %s\n  Kubernetes:    %s\n  Provider:      %s\n  CNI:           %s\n", plan.Context, plan.Detection.KubernetesVersion, plan.Detection.Provider, plan.Detection.CNI)
+	fmt.Fprintf(out, "\nComponents\n  Resources:     %d\n  Agent:         privileged DaemonSet\n  Relay:         %s\n  Mesh CIDR:     %s\n  Image:         %s\n", len(plan.Resources), plan.Relay, plan.MeshCIDR, plan.Image)
+	fmt.Fprintln(out, "\nInfrastructure impact")
+	for _, impact := range plan.Impact {
+		fmt.Fprintf(out, "  - %s\n", impact)
+	}
+	for _, warning := range plan.Warnings {
+		fmt.Fprintf(out, "  WARNING: %s\n", warning)
+	}
+}
+
+func writeLifecycleResult(cmd *cobra.Command, result internalinstall.Result) error {
+	if options.output == "json" {
+		return writeJSON(cmd.OutOrStdout(), result)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "WireKube %s completed: installation=%s ready=%t\n", result.Operation, result.InstallationID, result.Ready)
+	return nil
+}
+
+func confirm(in io.Reader, out io.Writer, prompt string) (bool, error) {
+	fmt.Fprint(out, prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && len(line) == 0 {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func messageForError(err error, success string) string {
+	if err == nil {
+		return success
+	}
+	if apierrors.IsNotFound(err) {
+		return "not found"
+	}
+	return err.Error()
+}

--- a/cmd/wirekubectl/main.go
+++ b/cmd/wirekubectl/main.go
@@ -14,35 +14,90 @@ import (
 
 	qrcode "github.com/skip2/go-qrcode"
 	"github.com/spf13/cobra"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/yaml"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/externalpeer"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	internalconfig "github.com/inerplat/wirekube/internal/kubeconfig"
+	internalversion "github.com/inerplat/wirekube/internal/version"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/externalpeer"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 var scheme = runtime.NewScheme()
 
+type globalOptions struct {
+	kubeconfig string
+	context    string
+	namespace  string
+	timeout    time.Duration
+	output     string
+	client     func() (client.Client, error)
+}
+
+var options = &globalOptions{}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(wirekubev1alpha1.AddToScheme(scheme))
-	ctrl.SetLogger(zap.New(zap.WriteTo(os.Stderr)))
 }
 
 func main() {
-	root := &cobra.Command{
-		Use:   "wirekubectl",
-		Short: "WireKube CLI — manage your Kubernetes WireGuard mesh",
+	root := newRootCommand()
+	root.SetOut(os.Stdout)
+	root.SetErr(os.Stderr)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		if options.output == "json" {
+			_ = writeJSON(os.Stderr, map[string]any{
+				"schemaVersion": "v1alpha1",
+				"error": map[string]string{
+					"code":    "command_failed",
+					"message": err.Error(),
+				},
+			})
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		os.Exit(1)
 	}
+}
+
+func newRootCommand() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "wirekubectl",
+		Short:         "Manage and install WireKube",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			switch options.output {
+			case "text", "json":
+				return nil
+			default:
+				return fmt.Errorf("unsupported output format %q: use text or json", options.output)
+			}
+		},
+	}
+	root.PersistentFlags().StringVar(&options.kubeconfig, "kubeconfig", "", "path to the kubeconfig file")
+	root.PersistentFlags().StringVar(&options.context, "context", "", "kubeconfig context to use")
+	root.PersistentFlags().StringVar(&options.namespace, "namespace", "wirekube-system", "namespace for WireKube workloads")
+	root.PersistentFlags().DurationVar(&options.timeout, "timeout", 5*time.Minute, "timeout for Kubernetes operations")
+	root.PersistentFlags().StringVar(&options.output, "output", "text", "output format: text or json")
 
 	root.AddCommand(
+		versionCmd(),
+		installCmd(),
+		statusCmd(),
+		doctorCmd(),
+		upgradeCmd(),
+		uninstallCmd(),
+		manifestCmd(),
 		meshCmd(),
 		peersCmd(),
 		exportCmd(),
@@ -52,19 +107,47 @@ func main() {
 		inviteCmd(),
 		revokeCmd(),
 	)
-
-	if err := root.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return root
 }
 
 func k8sClient() (client.Client, error) {
-	return client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if options.client != nil {
+		return options.client()
+	}
+	factory := internalconfig.New(internalconfig.Options{
+		Kubeconfig: options.kubeconfig,
+		Context:    options.context,
+		Namespace:  options.namespace,
+		Timeout:    options.timeout,
+	}, scheme)
+	return factory.Client()
+}
+
+func versionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Show wirekubectl build information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			info := internalversion.Current()
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), info)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Version:       %s\n", info.Version)
+			fmt.Fprintf(cmd.OutOrStdout(), "Commit:        %s\n", info.Commit)
+			fmt.Fprintf(cmd.OutOrStdout(), "Build date:    %s\n", info.BuildDate)
+			fmt.Fprintf(cmd.OutOrStdout(), "Default image: %s\n", valueOrDash(info.DefaultImage))
+			return nil
+		},
+	}
 }
 
 // mesh
 func meshCmd() *cobra.Command {
-	var listenPort int32
+	var (
+		listenPort  int32
+		stunServers []string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "mesh",
@@ -73,7 +156,8 @@ func meshCmd() *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:   "init",
-		Short: "Create or update the WireKubeMesh resource",
+		Short: "Create the default WireKubeMesh or patch explicitly supplied fields",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := k8sClient()
 			if err != nil {
@@ -82,33 +166,44 @@ func meshCmd() *cobra.Command {
 			mesh := &wirekubev1alpha1.WireKubeMesh{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
 				Spec: wirekubev1alpha1.WireKubeMeshSpec{
-					ListenPort: listenPort,
-					STUNServers: []string{
-						"stun:stun.l.google.com:19302",
-						"stun:stun1.l.google.com:19302",
-					},
+					ListenPort:  listenPort,
+					STUNServers: append([]string(nil), stunServers...),
 				},
 			}
-			ctx := context.Background()
+			ctx := cmd.Context()
 			existing := &wirekubev1alpha1.WireKubeMesh{}
 			err = c.Get(ctx, client.ObjectKey{Name: "default"}, existing)
-			if err != nil {
+			if apierrors.IsNotFound(err) {
 				if err := c.Create(ctx, mesh); err != nil {
-					return err
+					return fmt.Errorf("create WireKubeMesh: %w", err)
 				}
-				fmt.Println("WireKubeMesh 'default' created")
-			} else {
-				patch := client.MergeFrom(existing.DeepCopy())
-				existing.Spec = mesh.Spec
-				if err := c.Patch(ctx, existing, patch); err != nil {
-					return err
-				}
-				fmt.Println("WireKubeMesh 'default' updated")
+				return writeResult(cmd, map[string]any{"name": "default", "operation": "created"}, "WireKubeMesh 'default' created\n")
 			}
-			return nil
+			if err != nil {
+				return fmt.Errorf("get WireKubeMesh: %w", err)
+			}
+
+			patch := client.MergeFrom(existing.DeepCopy())
+			changed := false
+			if cmd.Flags().Changed("port") && existing.Spec.ListenPort != listenPort {
+				existing.Spec.ListenPort = listenPort
+				changed = true
+			}
+			if cmd.Flags().Changed("stun-server") && !stringSlicesEqual(existing.Spec.STUNServers, stunServers) {
+				existing.Spec.STUNServers = append([]string(nil), stunServers...)
+				changed = true
+			}
+			if changed {
+				if err := c.Patch(ctx, existing, patch); err != nil {
+					return fmt.Errorf("patch WireKubeMesh: %w", err)
+				}
+				return writeResult(cmd, map[string]any{"name": "default", "operation": "patched"}, "WireKubeMesh 'default' patched\n")
+			}
+			return writeResult(cmd, map[string]any{"name": "default", "operation": "unchanged"}, "WireKubeMesh 'default' already exists; no fields were changed\n")
 		},
 	}
 	initCmd.Flags().Int32Var(&listenPort, "port", 51820, "WireGuard listen port")
+	initCmd.Flags().StringSliceVar(&stunServers, "stun-server", []string{"stun:stun.l.google.com:19302", "stun:stun1.l.google.com:19302"}, "STUN server; may be repeated")
 	cmd.AddCommand(initCmd)
 
 	statusCmd := &cobra.Command{
@@ -120,14 +215,17 @@ func meshCmd() *cobra.Command {
 				return err
 			}
 			mesh := &wirekubev1alpha1.WireKubeMesh{}
-			if err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, mesh); err != nil {
-				return err
+			if err := c.Get(cmd.Context(), client.ObjectKey{Name: "default"}, mesh); err != nil {
+				return fmt.Errorf("get WireKubeMesh: %w", err)
 			}
-			fmt.Printf("Name:        %s\n", mesh.Name)
-			fmt.Printf("Listen Port: %d\n", mesh.Spec.ListenPort)
-			fmt.Printf("Interface:   %s\n", mesh.Spec.InterfaceName)
-			fmt.Printf("MTU:         %d\n", mesh.Spec.MTU)
-			fmt.Printf("Ready Peers: %d / %d\n", mesh.Status.ReadyPeers, mesh.Status.TotalPeers)
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), mesh)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Name:        %s\n", mesh.Name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Listen Port: %d\n", mesh.Spec.ListenPort)
+			fmt.Fprintf(cmd.OutOrStdout(), "Interface:   %s\n", mesh.Spec.InterfaceName)
+			fmt.Fprintf(cmd.OutOrStdout(), "MTU:         %d\n", mesh.Spec.MTU)
+			fmt.Fprintf(cmd.OutOrStdout(), "Ready Peers: %d / %d\n", mesh.Status.ReadyPeers, mesh.Status.TotalPeers)
 			return nil
 		},
 	}
@@ -147,11 +245,14 @@ func peersCmd() *cobra.Command {
 				return err
 			}
 			peerList := &wirekubev1alpha1.WireKubePeerList{}
-			if err := c.List(context.Background(), peerList); err != nil {
+			if err := c.List(cmd.Context(), peerList); err != nil {
 				return err
 			}
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), peerList.Items)
+			}
 
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 			fmt.Fprintln(w, "NAME\tENDPOINT\tALLOWED-IPS\tCONNECTED\tLAST HANDSHAKE")
 			for _, p := range peerList.Items {
 				lastHS := "-"
@@ -186,8 +287,11 @@ func exportCmd() *cobra.Command {
 				return err
 			}
 			peerList := &wirekubev1alpha1.WireKubePeerList{}
-			if err := c.List(context.Background(), peerList); err != nil {
+			if err := c.List(cmd.Context(), peerList); err != nil {
 				return err
+			}
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), peerList.Items)
 			}
 
 			for i, p := range peerList.Items {
@@ -211,9 +315,9 @@ func exportCmd() *cobra.Command {
 					return err
 				}
 				if i > 0 {
-					fmt.Println("---")
+					fmt.Fprintln(cmd.OutOrStdout(), "---")
 				}
-				fmt.Print(string(b))
+				fmt.Fprint(cmd.OutOrStdout(), string(b))
 			}
 			return nil
 		},
@@ -249,19 +353,19 @@ func importCmd() *cobra.Command {
 				}
 
 				existing := &wirekubev1alpha1.WireKubePeer{}
-				err := c.Get(context.Background(), client.ObjectKey{Name: peer.Name}, existing)
+				err := c.Get(cmd.Context(), client.ObjectKey{Name: peer.Name}, existing)
 				if err != nil {
-					if err := c.Create(context.Background(), peer); err != nil {
+					if err := c.Create(cmd.Context(), peer); err != nil {
 						return fmt.Errorf("creating peer %s: %w", peer.Name, err)
 					}
-					fmt.Printf("created peer %s\n", peer.Name)
+					fmt.Fprintf(cmd.OutOrStdout(), "created peer %s\n", peer.Name)
 				} else {
 					patch := client.MergeFrom(existing.DeepCopy())
 					existing.Spec = peer.Spec
-					if err := c.Patch(context.Background(), existing, patch); err != nil {
+					if err := c.Patch(cmd.Context(), existing, patch); err != nil {
 						return fmt.Errorf("updating peer %s: %w", peer.Name, err)
 					}
-					fmt.Printf("updated peer %s\n", peer.Name)
+					fmt.Fprintf(cmd.OutOrStdout(), "updated peer %s\n", peer.Name)
 				}
 			}
 			return nil
@@ -280,8 +384,8 @@ func tokenCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a new bootstrap token for enrolling a node",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("# Bootstrap token creation not yet implemented.")
-			fmt.Println("# Use kubeadm token create or manually create a ServiceAccount for the agent.")
+			fmt.Fprintln(cmd.OutOrStdout(), "# Bootstrap token creation not yet implemented.")
+			fmt.Fprintln(cmd.OutOrStdout(), "# Use kubeadm token create or manually create a ServiceAccount for the agent.")
 			return nil
 		},
 	}
@@ -300,7 +404,7 @@ func externalCmd() *cobra.Command {
 		Short:   "Manage external WireGuard clients",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listExternalPeers(cmd.Context(), os.Stdout)
+			return listExternalPeers(cmd.Context(), cmd.OutOrStdout())
 		},
 	}
 	cmd.AddCommand(
@@ -319,7 +423,7 @@ func externalListCmd() *cobra.Command {
 		Short:   "List external WireGuard clients",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listExternalPeers(cmd.Context(), os.Stdout)
+			return listExternalPeers(cmd.Context(), cmd.OutOrStdout())
 		},
 	}
 }
@@ -339,7 +443,10 @@ func externalGetCmd() *cobra.Command {
 			if err := c.Get(cmd.Context(), client.ObjectKey{Name: args[0]}, cr); err != nil {
 				return fmt.Errorf("get external peer: %w", err)
 			}
-			writeExternalPeerDetail(os.Stdout, cr)
+			if options.output == "json" {
+				return writeJSON(cmd.OutOrStdout(), cr)
+			}
+			writeExternalPeerDetail(cmd.OutOrStdout(), cr)
 			return nil
 		},
 	}
@@ -359,7 +466,7 @@ func externalRemoveCmd() *cobra.Command {
 			if err := removeExternalPeer(cmd.Context(), c, args[0]); err != nil {
 				return err
 			}
-			fmt.Printf("removed external peer %s\n", args[0])
+			fmt.Fprintf(cmd.OutOrStdout(), "removed external peer %s\n", args[0])
 			return nil
 		},
 	}
@@ -373,6 +480,9 @@ func listExternalPeers(ctx context.Context, out io.Writer) error {
 	peerList := &wirekubev1alpha1.WireKubeExternalPeerList{}
 	if err := c.List(ctx, peerList); err != nil {
 		return err
+	}
+	if options.output == "json" {
+		return writeJSON(out, peerList.Items)
 	}
 	return writeExternalPeerTable(out, peerList.Items, time.Now())
 }
@@ -485,7 +595,7 @@ cluster never sees it.`,
 				cr.Spec.MTU = mtu
 			}
 
-			ctx := context.Background()
+			ctx := cmd.Context()
 			if err := c.Create(ctx, cr); err != nil {
 				return fmt.Errorf("create WireKubeExternalPeer: %w", err)
 			}
@@ -500,17 +610,17 @@ cluster never sees it.`,
 				if err := os.WriteFile(outputFile, []byte(conf), 0o600); err != nil {
 					return fmt.Errorf("write conf: %w", err)
 				}
-				fmt.Fprintf(os.Stderr, "wrote conf to %s\n", outputFile)
+				fmt.Fprintf(cmd.ErrOrStderr(), "wrote conf to %s\n", outputFile)
 			} else {
-				fmt.Print(conf)
+				fmt.Fprint(cmd.OutOrStdout(), conf)
 			}
 			if printQR {
 				qr, err := qrcode.New(conf, qrcode.Low)
 				if err != nil {
 					return fmt.Errorf("encode QR: %w", err)
 				}
-				fmt.Println()
-				fmt.Println(qr.ToSmallString(false))
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.OutOrStdout(), qr.ToSmallString(false))
 			}
 			return nil
 		},
@@ -521,7 +631,7 @@ cluster never sees it.`,
 	cmd.Flags().Int32Var(&mtu, "mtu", 0, "WireGuard interface MTU for the external client (default: controller-recommended 1248)")
 	cmd.Flags().DurationVar(&waitFor, "wait", 60*time.Second, "how long to wait for Phase=Active before failing")
 	cmd.Flags().BoolVar(&printQR, "qr", true, "print an ASCII QR code of the conf for mobile import")
-	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "write the conf to this file instead of stdout (still prints QR if --qr)")
+	cmd.Flags().StringVarP(&outputFile, "output-file", "o", "", "write the conf to this file instead of stdout (still prints QR if --qr)")
 	return cmd
 }
 
@@ -540,7 +650,7 @@ func revokeCmd() *cobra.Command {
 			if err := removeExternalPeer(cmd.Context(), c, args[0]); err != nil {
 				return err
 			}
-			fmt.Printf("revoked %s\n", args[0])
+			fmt.Fprintf(cmd.OutOrStdout(), "revoked %s\n", args[0])
 			return nil
 		},
 	}
@@ -565,6 +675,32 @@ func valueOrDash(s string) string {
 		return "-"
 	}
 	return s
+}
+
+func writeJSON(out io.Writer, value any) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func writeResult(cmd *cobra.Command, value any, text string) error {
+	if options.output == "json" {
+		return writeJSON(cmd.OutOrStdout(), value)
+	}
+	_, err := fmt.Fprint(cmd.OutOrStdout(), text)
+	return err
+}
+
+func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func marshalYAML(v any) ([]byte, error) {

--- a/cmd/wirekubectl/main_test.go
+++ b/cmd/wirekubectl/main_test.go
@@ -2,15 +2,219 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/externalpeer"
+	internalinstall "github.com/inerplat/wirekube/internal/install"
+	internalversion "github.com/inerplat/wirekube/internal/version"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/externalpeer"
 )
+
+const lifecycleTestImage = "registry.example.test/wirekube@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestMeshInitPreservesExistingSpec(t *testing.T) {
+	mesh := &wirekubev1alpha1.WireKubeMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: wirekubev1alpha1.WireKubeMeshSpec{
+			ListenPort: 51822,
+			MeshCIDR:   "198.18.0.0/16",
+			Relay: &wirekubev1alpha1.RelaySpec{
+				Mode:     "always",
+				Provider: "external",
+				External: &wirekubev1alpha1.ExternalRelaySpec{Endpoint: "relay.example.test:3478"},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mesh).Build()
+	runMeshInit(t, c)
+
+	got := &wirekubev1alpha1.WireKubeMesh{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.ListenPort != 51822 || got.Spec.MeshCIDR != "198.18.0.0/16" || got.Spec.Relay == nil || got.Spec.Relay.Mode != "always" {
+		t.Fatalf("existing spec was changed: %+v", got.Spec)
+	}
+}
+
+func TestMeshInitPatchesOnlyExplicitPort(t *testing.T) {
+	mesh := &wirekubev1alpha1.WireKubeMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: wirekubev1alpha1.WireKubeMeshSpec{
+			ListenPort: 51820,
+			MeshCIDR:   "198.18.0.0/16",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mesh).Build()
+	runMeshInit(t, c, "--port", "51999")
+
+	got := &wirekubev1alpha1.WireKubeMesh{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.ListenPort != 51999 || got.Spec.MeshCIDR != "198.18.0.0/16" {
+		t.Fatalf("unexpected spec: %+v", got.Spec)
+	}
+}
+
+func TestVersionJSON(t *testing.T) {
+	original := internalversion.Current()
+	internalversion.Version = "v1.2.3"
+	internalversion.Commit = "abcdef0"
+	internalversion.BuildDate = "2026-07-12T00:00:00Z"
+	t.Cleanup(func() {
+		internalversion.Version = original.Version
+		internalversion.Commit = original.Commit
+		internalversion.BuildDate = original.BuildDate
+		internalversion.DefaultImage = original.DefaultImage
+	})
+
+	oldOutput := options.output
+	options.output = "json"
+	t.Cleanup(func() { options.output = oldOutput })
+	var out bytes.Buffer
+	cmd := versionCmd()
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var got internalversion.Info
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != "v1.2.3" || got.Commit != "abcdef0" {
+		t.Fatalf("version info=%+v", got)
+	}
+}
+
+func TestUninstallPurgeRequiresSeparateConfirmationFlag(t *testing.T) {
+	oldOutput := options.output
+	options.output = "text"
+	t.Cleanup(func() { options.output = oldOutput })
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"uninstall", "--purge", "--yes"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--confirm-purge") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestInstallJSONRequiresNonInteractiveAcknowledgement(t *testing.T) {
+	oldOutput := options.output
+	options.output = "text"
+	t.Cleanup(func() { options.output = oldOutput })
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"install", "--output", "json"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "--yes or --dry-run") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestInspectInstallationIncludesCRDAgentAndMeshReadiness(t *testing.T) {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekubemeshes.wirekube.io", Labels: map[string]string{"app.kubernetes.io/managed-by": "wirekubectl"}},
+		Status:     apiextensionsv1.CustomResourceDefinitionStatus{Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue}}},
+	}
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekube-agent", Namespace: "wirekube-system", Labels: map[string]string{"app.kubernetes.io/managed-by": "wirekubectl"}},
+		Spec:       appsv1.DaemonSetSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "agent", Image: lifecycleTestImage}}}}},
+		Status:     appsv1.DaemonSetStatus{DesiredNumberScheduled: 2, UpdatedNumberScheduled: 2, NumberReady: 2, NumberAvailable: 2},
+	}
+	mesh := &wirekubev1alpha1.WireKubeMesh{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: map[string]string{"app.kubernetes.io/managed-by": "wirekubectl"}},
+		Status:     wirekubev1alpha1.WireKubeMeshStatus{TotalPeers: 2, ReadyPeers: 1},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crd, daemonSet, mesh).Build()
+	inventory := &internalinstall.Inventory{
+		InstallationID:  "installation-1",
+		WireKubeVersion: "v1.0.0",
+		Image:           lifecycleTestImage,
+		Options:         internalinstall.Options{Namespace: "wirekube-system", Relay: internalinstall.RelayNone},
+		Resources: []internalinstall.Resource{
+			{APIVersion: apiextensionsv1.SchemeGroupVersion.String(), Kind: "CustomResourceDefinition", Name: crd.Name, Preserve: true},
+			{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: "DaemonSet", Namespace: daemonSet.Namespace, Name: daemonSet.Name},
+			{APIVersion: wirekubev1alpha1.GroupVersion.String(), Kind: "WireKubeMesh", Name: mesh.Name, Preserve: true},
+		},
+	}
+
+	status := inspectInstallation(context.Background(), c, inventory)
+	if status.Ready || !status.ComponentsReady || status.ConnectivityReady {
+		t.Fatalf("status should distinguish installed components from incomplete connectivity: %+v", status)
+	}
+	if len(status.Components) != 3 {
+		t.Fatalf("components=%v", status.Components)
+	}
+}
+
+func TestWriteDoctorResultReturnsFailureAfterWritingJSON(t *testing.T) {
+	oldOutput := options.output
+	options.output = "json"
+	t.Cleanup(func() { options.output = oldOutput })
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := writeDoctorResult(cmd, doctorOutput{SchemaVersion: internalinstall.SchemaVersion, Ready: false, Checks: []doctorCheck{{Name: "mesh", OK: false, Message: "not connected"}}})
+	if err == nil || !strings.Contains(err.Error(), "failed checks") {
+		t.Fatalf("error=%v", err)
+	}
+	if !strings.Contains(out.String(), `"ready": false`) || !strings.Contains(out.String(), `"mesh"`) {
+		t.Fatalf("JSON output=%s", out.String())
+	}
+}
+
+func TestUpgradeUsesReleasedDefaultImageInsteadOfStoredImage(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("image", "", "")
+	flags := &lifecycleFlags{image: lifecycleTestImage}
+	stored := internalinstall.Options{Image: "registry.example.test/wirekube@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+
+	applyStoredLifecycleDefaults(cmd, flags, stored)
+	if flags.image != lifecycleTestImage {
+		t.Fatalf("image=%q, want released CLI default", flags.image)
+	}
+
+	flags.image = ""
+	applyStoredLifecycleDefaults(cmd, flags, stored)
+	if flags.image != stored.Image {
+		t.Fatalf("image=%q, want stored fallback %q", flags.image, stored.Image)
+	}
+}
+
+func runMeshInit(t *testing.T, c client.Client, args ...string) {
+	t.Helper()
+	oldClient, oldOutput := options.client, options.output
+	options.client = func() (client.Client, error) { return c, nil }
+	options.output = "text"
+	t.Cleanup(func() {
+		options.client = oldClient
+		options.output = oldOutput
+	})
+	cmd := meshCmd()
+	cmd.SetArgs(append([]string{"init"}, args...))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestRenderConfIncludesExternalPeerMTU(t *testing.T) {
 	conf := externalpeer.RenderConfig("private", &wirekubev1alpha1.WireKubeExternalPeer{

--- a/config/crd/embed.go
+++ b/config/crd/embed.go
@@ -1,0 +1,8 @@
+package crd
+
+import "embed"
+
+// Files contains the CRDs shipped with wirekubectl.
+//
+//go:embed *.yaml
+var Files embed.FS

--- a/config/crd/wirekube.io_wirekubemeshes.yaml
+++ b/config/crd/wirekube.io_wirekubemeshes.yaml
@@ -201,8 +201,9 @@ spec:
                         type: string
                       endpoint:
                         description: |-
-                          Endpoint is the relay server address (host:port).
+                          Endpoint is the raw WireGuard UDP address advertised to external peers.
                           Example: "relay.example.com:3478" or "203.0.113.10:3478"
+                          Leave empty when no UDP entrypoint is available; external peers remain Pending.
                         type: string
                       transport:
                         default: tcp
@@ -214,8 +215,6 @@ spec:
                         - ws
                         - wss
                         type: string
-                    required:
-                    - endpoint
                     type: object
                   handshakeTimeoutSeconds:
                     default: 30
@@ -291,7 +290,7 @@ spec:
                     description: |-
                       Provider selects how the relay server is provisioned.
                       "external": user provides a pre-existing relay endpoint (public IP server, third-party).
-                      "managed": operator deploys and manages the relay as a Pod + LoadBalancer Service.
+                      "managed": the installation owner provisions the relay resources and agents use the cluster-local control Service.
                     enum:
                     - external
                     - managed

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -62,9 +62,7 @@ docker push inerplat/wirekube:latest
 
 ### CI/CD
 
-Images are built and pushed automatically via GitHub Actions on tag push (`v*`).
-The workflow builds multi-arch images (amd64 + arm64) and pushes both the tagged
-version and `latest`.
+Tag builds run formatting, vet, lint, unit tests, and the TCP/WSS disposable-cluster E2E matrix before publishing anything. After those gates pass, the workflow publishes the multi-architecture image, builds four standalone `wirekubectl` binaries, injects the version, commit, build date, and immutable image digest, and creates a GitHub Release with SHA256 checksums.
 
 ## Dockerfile
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,16 +1,56 @@
 # Installation
 
-## Container Image
+## Install with wirekubectl
 
-The official multi-arch container image supports `linux/amd64` and `linux/arm64`:
+Release assets contain standalone `wirekubectl` binaries for macOS and Linux on AMD64 and ARM64. Download the binary and checksum file for the version you want from the [GitHub Releases](https://github.com/inerplat/wirekube/releases) page, verify the checksum, and place the binary on your `PATH`. Each release also includes `wirekube-release.json` with the immutable container image digest embedded in that CLI.
 
 ```bash
-docker pull inerplat/wirekube:latest
+VERSION=v0.0.14
+curl -fLO "https://github.com/inerplat/wirekube/releases/download/${VERSION}/wirekubectl-linux-amd64"
+curl -fLO "https://github.com/inerplat/wirekube/releases/download/${VERSION}/wirekubectl-checksums.txt"
+sha256sum --check --ignore-missing wirekubectl-checksums.txt
+chmod +x wirekubectl-linux-amd64
+sudo install wirekubectl-linux-amd64 /usr/local/bin/wirekubectl
 ```
 
-Tagged releases are built automatically via GitHub Actions on tag push (`v*`).
+The released CLI contains the matching immutable container image digest. Interactive installation inspects the target cluster and prints the complete resource and infrastructure plan before making changes:
 
-## Install from Manifests
+```bash
+wirekubectl install --kubeconfig ~/.kube/config --context my-cluster
+```
+
+Non-interactive installation must explicitly select the relay topology, especially when it creates a public LoadBalancer:
+
+```bash
+wirekubectl install --kubeconfig ~/.kube/config --context my-cluster --relay load-balancer --mesh-cidr 100.96.0.0/11 --node-addresses internal-ip --yes --output json
+```
+
+Use `--dry-run` to inspect the same plan without creating the Namespace, CRDs, or any workloads. Automatic mesh CIDR selection is best effort because the CLI cannot inspect every VPC, corporate, or node route; add known routes with `--exclude-cidr`, review the selected candidate, and provide an explicit `--mesh-cidr` for non-interactive installation. Use `wirekubectl manifest` to render the exact resources selected by the plan.
+
+`--relay-udp` creates a separate UDP Service instead of requiring a mixed-protocol LoadBalancer. With `--relay node-port`, agents use TCP NodePort `30478` while external WireGuard traffic uses UDP NodePort `30479`; supply the reachable node address as `--relay-endpoint HOST:30478`. A TCP-only relay does not provide a raw WireGuard endpoint, so external peer invites remain Pending until UDP is enabled. For `--relay external`, use `--relay-endpoint HOST:PORT` for the agent control connection and optionally use `--relay-udp-endpoint HOST:PORT` for raw WireGuard external peers.
+
+WireKube is a cluster-wide singleton because its CRDs, mesh, and RBAC are cluster-scoped. `--namespace` chooses where workloads and inventory run; it does not permit a second installation in another namespace. Every managed resource is stamped with the inventory installation ID, and upgrade or uninstall refuses resources owned by a different installation.
+
+## Lifecycle commands
+
+```bash
+wirekubectl status
+wirekubectl doctor
+wirekubectl upgrade
+wirekubectl uninstall
+```
+
+`wirekubectl upgrade` keeps the stored topology unless flags override it and uses the immutable image digest embedded in the new released CLI. Upgrade snapshots existing objects and inventory before mutation; readiness, inventory, or stale-resource deletion failures restore the previous objects and inventory. Resources removed from the selected topology, such as a disabled UDP relay Service, are deleted only when their inventory ownership is still valid.
+
+Default uninstall removes resources recorded in the installation inventory while preserving CRDs and WireKube custom resources. Destructive removal requires both `--purge` and `--confirm-purge`; ordinary `--yes` never implies data deletion.
+
+## Container Image
+
+The official multi-architecture container image supports `linux/amd64` and `linux/arm64`. Installation resources use the digest embedded in the matching `wirekubectl` release and do not use `latest` or development tags.
+
+## Install from repository manifests
+
+The repository manifests remain available for development and manual inspection. They are not the primary release installation contract because they may contain environment-specific examples and require a source checkout.
 
 ### 1. CRDs
 
@@ -144,11 +184,12 @@ spec:
   relay:
     provider: external
     external:
-      endpoint: "relay.example.com:3478"
+      controlEndpoint: "relay.example.com:3478"
+      endpoint: "relay.example.com:51820"
       transport: tcp
 ```
 
-## Uninstall
+## Manual manifest uninstall
 
 ```bash
 kubectl delete -f config/agent/ --ignore-not-found

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -93,11 +93,18 @@ wirekube-relay --addr 10.0.0.1:3478
 
 ## wirekubectl
 
-CLI tool for inspecting mesh status.
+CLI tool for installing WireKube and managing mesh resources without requiring a source checkout.
 
 ### Usage
 
 ```bash
+wirekubectl version
+wirekubectl install [flags]
+wirekubectl manifest [flags]
+wirekubectl status
+wirekubectl doctor
+wirekubectl upgrade [flags]
+wirekubectl uninstall [--purge --confirm-purge]
 wirekubectl mesh status
 wirekubectl peers
 wirekubectl export
@@ -108,5 +115,17 @@ wirekubectl external get <name>
 wirekubectl external invite <display-name> [flags]
 wirekubectl external revoke <display-name>
 ```
+
+All commands accept `--kubeconfig`, `--context`, `--namespace`, `--timeout`, and `--output text|json`. `install --dry-run` performs cluster inspection and prints the installation plan without mutation. Non-interactive `install --yes` requires explicit `--relay` and `--mesh-cidr` selections and an image pinned as `IMAGE@sha256:DIGEST` unless the released CLI already contains its matching default image digest. `--exclude-cidr` records routes that best-effort automatic mesh CIDR selection must avoid.
+
+`--relay-endpoint` is the TCP control endpoint for NodePort or external relay modes. `--relay-udp-endpoint` is a separate raw WireGuard endpoint for external peer invites and is valid with `--relay external`; NodePort derives UDP port `30479` when `--relay-udp` is enabled. TCP-only relay installations leave external peers Pending instead of publishing an unusable UDP configuration.
+
+`status` reports component deployment readiness separately from mesh connectivity readiness, including CRD establishment, agent image and rollout state, ReadyPeers, relay readiness, and LoadBalancer or NodePort assignment. `doctor` adds API connectivity, installation-ID ownership, and relay TCP reachability checks, writes the complete text or JSON report, and exits non-zero when any check fails. JSON command failures use a stable `schemaVersion` and `error.code`/`error.message` envelope.
+
+WireKube supports one installation per cluster because the mesh, CRDs, and RBAC are cluster-scoped. `--namespace` selects the workload and inventory namespace; install refuses an inventory in another namespace, and upgrade or uninstall refuses resources whose installation ID does not match.
+
+`mesh init` creates the default mesh when it is absent. When the mesh already exists, it patches only flags explicitly provided on the command line and never replaces the complete spec.
+
+`uninstall` preserves CRDs and custom resources by default. `--purge` is rejected unless `--confirm-purge` is also present, and `--yes` alone never authorizes purge.
 
 `wirekubectl token create` is currently a placeholder that prints guidance and does not issue a token. The WSS relay uses Kubernetes `kubectl create token` and TokenReview instead.

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/wirekube/wirekube
+module github.com/inerplat/wirekube
 
 go 1.23
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/huin/goupnp v1.3.0
 	github.com/pion/stun/v3 v3.0.0
@@ -17,6 +18,7 @@ require (
 	golang.org/x/time v0.6.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	k8s.io/api v0.30.3
+	k8s.io/apiextensions-apiserver v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
 	sigs.k8s.io/controller-runtime v0.18.4
@@ -41,7 +43,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -75,7 +76,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.30.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240709000822-3c01b740850f // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/internal/install/installer.go
+++ b/internal/install/installer.go
@@ -1,0 +1,610 @@
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+)
+
+type Installer struct {
+	Client client.Client
+}
+
+func (i Installer) Apply(ctx context.Context, plan Plan, options Options, operation string) (Result, error) {
+	existingInventory, inventoryErr := i.LoadInventory(ctx, options.Namespace)
+	if err := i.ensureSingleton(ctx, options.Namespace); err != nil {
+		return Result{}, err
+	}
+	if operation == "install" && inventoryErr == nil {
+		if !sameInstallConfig(existingInventory.Options, options) {
+			return Result{}, fmt.Errorf("WireKube installation %s already exists with different options; use wirekubectl upgrade", existingInventory.InstallationID)
+		}
+	}
+	if operation == "upgrade" && apierrors.IsNotFound(inventoryErr) {
+		return Result{}, fmt.Errorf("WireKube is not installed; use wirekubectl install")
+	}
+	if inventoryErr != nil && !apierrors.IsNotFound(inventoryErr) {
+		return Result{}, inventoryErr
+	}
+
+	installationID := uuid.NewString()
+	installedAt := time.Now().UTC()
+	if existingInventory != nil {
+		installationID = existingInventory.InstallationID
+		installedAt = existingInventory.InstalledAt
+	}
+	bundle, err := Render(options)
+	if err != nil {
+		return Result{}, err
+	}
+	stampBundleInstallation(bundle, installationID)
+
+	allowLegacyOwnership := existingInventory != nil
+	journal := make([]rollbackAction, 0, len(bundle.CRDs)+len(bundle.Objects)+1)
+	fail := func(cause error) (Result, error) {
+		return Result{}, rollbackError(cause, journal)
+	}
+
+	for _, crd := range bundle.CRDs {
+		outcome, err := i.applyObject(ctx, crd, options.Adopt, installationID, allowLegacyOwnership)
+		if err != nil {
+			return fail(err)
+		}
+		journal = appendApplyRollback(journal, i.Client, outcome)
+	}
+	if err := i.waitForCRDs(ctx, bundle.CRDs); err != nil {
+		return fail(err)
+	}
+	for _, object := range bundle.Objects {
+		clientObject, ok := object.(client.Object)
+		if !ok {
+			return fail(fmt.Errorf("rendered object %T is not a Kubernetes client object", object))
+		}
+		outcome, err := i.applyObject(ctx, clientObject, options.Adopt, installationID, allowLegacyOwnership)
+		if err != nil {
+			return fail(err)
+		}
+		journal = appendApplyRollback(journal, i.Client, outcome)
+	}
+	if err := i.waitReady(ctx, options); err != nil {
+		return fail(err)
+	}
+
+	storedOptions := options
+	storedOptions.Yes = false
+	storedOptions.DryRun = false
+	storedOptions.Adopt = false
+	inventory := Inventory{
+		SchemaVersion:   SchemaVersion,
+		InstallationID:  installationID,
+		InstalledAt:     installedAt,
+		UpdatedAt:       time.Now().UTC(),
+		WireKubeVersion: options.WireKubeVersion,
+		Image:           options.Image,
+		Options:         storedOptions,
+		Resources:       bundle.Resources,
+	}
+	inventoryOutcome, err := i.saveInventory(ctx, options.Namespace, inventory, allowLegacyOwnership)
+	if err != nil {
+		return fail(err)
+	}
+	journal = appendApplyRollback(journal, i.Client, inventoryOutcome)
+	if operation == "upgrade" && existingInventory != nil {
+		for _, resource := range staleResources(existingInventory.Resources, bundle.Resources) {
+			deleted, err := i.deleteManagedResource(ctx, resource, installationID)
+			if err != nil {
+				return fail(fmt.Errorf("remove resources no longer selected by the upgrade: %w", err))
+			}
+			if deleted != nil {
+				journal = append(journal, restoreRollback(i.Client, deleted))
+			}
+		}
+	}
+	return Result{SchemaVersion: SchemaVersion, Operation: operation, InstallationID: installationID, Ready: true, Plan: plan, CompletedAt: time.Now().UTC()}, nil
+}
+
+func sameInstallConfig(left, right Options) bool {
+	return left.Namespace == right.Namespace &&
+		left.Image == right.Image &&
+		left.Relay == right.Relay &&
+		left.RelayEndpoint == right.RelayEndpoint &&
+		left.RelayUDPEndpoint == right.RelayUDPEndpoint &&
+		left.RelayUDP == right.RelayUDP &&
+		left.MeshCIDR == right.MeshCIDR &&
+		left.NodeAddresses == right.NodeAddresses
+}
+
+type applyOutcome struct {
+	applied  client.Object
+	previous client.Object
+	created  bool
+	changed  bool
+}
+
+type rollbackAction struct {
+	description string
+	run         func(context.Context) error
+}
+
+func stampBundleInstallation(bundle *Bundle, installationID string) {
+	for _, crd := range bundle.CRDs {
+		setInstallationID(crd, installationID)
+	}
+	for _, object := range bundle.Objects {
+		if clientObject, ok := object.(client.Object); ok {
+			setInstallationID(clientObject, installationID)
+		}
+	}
+}
+
+func setInstallationID(object metav1.Object, installationID string) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	} else {
+		labels = copyLabels(labels)
+	}
+	labels[InstallationIDLabel] = installationID
+	object.SetLabels(labels)
+}
+
+func (i Installer) ensureSingleton(ctx context.Context, namespace string) error {
+	configMaps := &corev1.ConfigMapList{}
+	if err := i.Client.List(ctx, configMaps); err != nil {
+		return fmt.Errorf("list WireKube installation inventories: %w", err)
+	}
+	for index := range configMaps.Items {
+		configMap := &configMaps.Items[index]
+		if configMap.Name != InventoryName || configMap.Namespace == namespace {
+			continue
+		}
+		inventory := &Inventory{}
+		if err := json.Unmarshal([]byte(configMap.Data["inventory.json"]), inventory); err != nil {
+			return fmt.Errorf("WireKube installation inventory in namespace %s is invalid: %w", configMap.Namespace, err)
+		}
+		return fmt.Errorf("WireKube is already installed cluster-wide in namespace %s as installation %s; use that namespace for upgrade or uninstall", configMap.Namespace, inventory.InstallationID)
+	}
+	return nil
+}
+
+func (i Installer) applyObject(ctx context.Context, desired client.Object, adopt bool, installationID string, allowLegacyOwnership bool) (applyOutcome, error) {
+	existing := reflect.New(reflect.TypeOf(desired).Elem()).Interface().(client.Object)
+	err := i.Client.Get(ctx, client.ObjectKeyFromObject(desired), existing)
+	created := apierrors.IsNotFound(err)
+	if err != nil && !created {
+		return applyOutcome{}, fmt.Errorf("inspect %s %s: %w", desired.GetObjectKind().GroupVersionKind().Kind, desired.GetName(), err)
+	}
+	if !created {
+		if _, namespace := desired.(*corev1.Namespace); namespace {
+			return applyOutcome{}, nil
+		}
+		labels := existing.GetLabels()
+		existingInstallationID := labels[InstallationIDLabel]
+		if existingInstallationID != "" && existingInstallationID != installationID {
+			return applyOutcome{}, fmt.Errorf("%s %s belongs to WireKube installation %s, refusing to take ownership for installation %s", desired.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(desired), existingInstallationID, installationID)
+		}
+		managed := labels["app.kubernetes.io/managed-by"] == "wirekubectl"
+		if !managed && !adopt {
+			return applyOutcome{}, fmt.Errorf("%s %s already exists and is not managed by wirekubectl; rerun with --adopt after reviewing it", desired.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(desired))
+		}
+		if managed && existingInstallationID == "" && !allowLegacyOwnership && !adopt {
+			return applyOutcome{}, fmt.Errorf("%s %s is managed by wirekubectl but has no installation ID; refusing to assume ownership without --adopt", desired.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(desired))
+		}
+	}
+	if err := i.Client.Patch(ctx, desired, client.Apply, client.FieldOwner(FieldManager)); err != nil {
+		return applyOutcome{}, fmt.Errorf("apply %s %s: %w", desired.GetObjectKind().GroupVersionKind().Kind, client.ObjectKeyFromObject(desired), err)
+	}
+	outcome := applyOutcome{applied: desired.DeepCopyObject().(client.Object), created: created, changed: true}
+	if !created {
+		outcome.previous = existing.DeepCopyObject().(client.Object)
+	}
+	return outcome, nil
+}
+
+func appendApplyRollback(journal []rollbackAction, c client.Client, outcome applyOutcome) []rollbackAction {
+	if !outcome.changed {
+		return journal
+	}
+	if outcome.created {
+		object := outcome.applied.DeepCopyObject().(client.Object)
+		installationID := object.GetLabels()[InstallationIDLabel]
+		return append(journal, rollbackAction{
+			description: "delete newly created " + object.GetName(),
+			run: func(ctx context.Context) error {
+				current := reflect.New(reflect.TypeOf(object).Elem()).Interface().(client.Object)
+				current.GetObjectKind().SetGroupVersionKind(object.GetObjectKind().GroupVersionKind())
+				if err := c.Get(ctx, client.ObjectKeyFromObject(object), current); err != nil {
+					return client.IgnoreNotFound(err)
+				}
+				if current.GetLabels()[InstallationIDLabel] != installationID {
+					return fmt.Errorf("resource ownership changed to installation %q", current.GetLabels()[InstallationIDLabel])
+				}
+				return client.IgnoreNotFound(c.Delete(ctx, current))
+			},
+		})
+	}
+	return append(journal, restoreRollback(c, outcome.previous))
+}
+
+func restoreRollback(c client.Client, snapshot client.Object) rollbackAction {
+	snapshot = snapshot.DeepCopyObject().(client.Object)
+	return rollbackAction{
+		description: "restore " + snapshot.GetName(),
+		run: func(ctx context.Context) error {
+			current := reflect.New(reflect.TypeOf(snapshot).Elem()).Interface().(client.Object)
+			current.GetObjectKind().SetGroupVersionKind(snapshot.GetObjectKind().GroupVersionKind())
+			err := c.Get(ctx, client.ObjectKeyFromObject(snapshot), current)
+			if apierrors.IsNotFound(err) {
+				toCreate := snapshot.DeepCopyObject().(client.Object)
+				toCreate.SetResourceVersion("")
+				toCreate.SetUID("")
+				toCreate.SetManagedFields(nil)
+				toCreate.SetCreationTimestamp(metav1.Time{})
+				return c.Create(ctx, toCreate)
+			}
+			if err != nil {
+				return err
+			}
+			toRestore := snapshot.DeepCopyObject().(client.Object)
+			toRestore.SetResourceVersion(current.GetResourceVersion())
+			return c.Update(ctx, toRestore)
+		},
+	}
+}
+
+func rollbackError(cause error, journal []rollbackAction) error {
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var failures []string
+	for index := len(journal) - 1; index >= 0; index-- {
+		if err := journal[index].run(rollbackCtx); err != nil {
+			failures = append(failures, journal[index].description+": "+err.Error())
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("%w; rollback failures: %s", cause, strings.Join(failures, "; "))
+	}
+	return cause
+}
+
+func (i Installer) waitForCRDs(ctx context.Context, crds []*apiextensionsv1.CustomResourceDefinition) error {
+	for _, desired := range crds {
+		if err := poll(ctx, time.Second, func() (bool, error) {
+			current := &apiextensionsv1.CustomResourceDefinition{}
+			if err := i.Client.Get(ctx, client.ObjectKey{Name: desired.Name}, current); err != nil {
+				return false, err
+			}
+			for _, condition := range current.Status.Conditions {
+				if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+					return true, nil
+				}
+			}
+			return false, nil
+		}); err != nil {
+			return fmt.Errorf("wait for CRD %s to become Established: %w", desired.Name, err)
+		}
+	}
+	return nil
+}
+
+func (i Installer) waitReady(ctx context.Context, options Options) error {
+	var desiredAgents int32
+	if err := poll(ctx, 2*time.Second, func() (bool, error) {
+		daemonSet := &appsv1.DaemonSet{}
+		if err := i.Client.Get(ctx, types.NamespacedName{Namespace: options.Namespace, Name: "wirekube-agent"}, daemonSet); err != nil {
+			return false, err
+		}
+		desiredAgents = daemonSet.Status.DesiredNumberScheduled
+		return desiredAgents > 0 &&
+			daemonSet.Status.ObservedGeneration >= daemonSet.Generation &&
+			daemonSet.Status.UpdatedNumberScheduled == desiredAgents &&
+			daemonSet.Status.NumberReady == desiredAgents &&
+			daemonSet.Status.NumberAvailable == desiredAgents, nil
+	}); err != nil {
+		return fmt.Errorf("agent DaemonSet did not become ready; run wirekubectl doctor: %w", err)
+	}
+	if err := poll(ctx, 2*time.Second, func() (bool, error) {
+		mesh := &wirekubev1alpha1.WireKubeMesh{}
+		if err := i.Client.Get(ctx, client.ObjectKey{Name: "default"}, mesh); err != nil {
+			return false, err
+		}
+		return mesh.Status.TotalPeers >= desiredAgents && mesh.Status.ReadyPeers >= desiredAgents, nil
+	}); err != nil {
+		return fmt.Errorf("WireKubeMesh did not establish connectivity for all %d agent peers; run wirekubectl doctor: %w", desiredAgents, err)
+	}
+	if options.Relay == RelayLoadBalancer || options.Relay == RelayNodePort {
+		if err := poll(ctx, 2*time.Second, func() (bool, error) {
+			deployment := &appsv1.Deployment{}
+			if err := i.Client.Get(ctx, types.NamespacedName{Namespace: options.Namespace, Name: "wirekube-relay"}, deployment); err != nil {
+				return false, err
+			}
+			return deployment.Status.ObservedGeneration >= deployment.Generation &&
+				deployment.Status.UpdatedReplicas == 1 &&
+				deployment.Status.ReadyReplicas == 1 &&
+				deployment.Status.AvailableReplicas == 1, nil
+		}); err != nil {
+			return fmt.Errorf("relay Deployment did not become ready; run wirekubectl doctor: %w", err)
+		}
+	}
+	if options.Relay == RelayLoadBalancer {
+		serviceNames := []string{"wirekube-relay"}
+		if options.RelayUDP {
+			serviceNames = append(serviceNames, "wirekube-relay-udp")
+		}
+		for _, name := range serviceNames {
+			if err := poll(ctx, 2*time.Second, func() (bool, error) {
+				service := &corev1.Service{}
+				if err := i.Client.Get(ctx, types.NamespacedName{Namespace: options.Namespace, Name: name}, service); err != nil {
+					return false, err
+				}
+				return len(service.Status.LoadBalancer.Ingress) > 0, nil
+			}); err != nil {
+				return fmt.Errorf("relay LoadBalancer Service %s has no external address; run wirekubectl doctor: %w", name, err)
+			}
+		}
+	}
+	if options.Relay == RelayNodePort {
+		serviceNames := []string{"wirekube-relay"}
+		if options.RelayUDP {
+			serviceNames = append(serviceNames, "wirekube-relay-udp")
+		}
+		for _, name := range serviceNames {
+			if err := poll(ctx, 2*time.Second, func() (bool, error) {
+				service := &corev1.Service{}
+				if err := i.Client.Get(ctx, types.NamespacedName{Namespace: options.Namespace, Name: name}, service); err != nil {
+					return false, err
+				}
+				return len(service.Spec.Ports) == 1 && service.Spec.Ports[0].NodePort > 0, nil
+			}); err != nil {
+				return fmt.Errorf("relay NodePort Service %s has no allocated node port; run wirekubectl doctor: %w", name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (i Installer) saveInventory(ctx context.Context, namespace string, inventory Inventory, allowLegacyOwnership bool) (applyOutcome, error) {
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		return applyOutcome{}, err
+	}
+	configMap := &corev1.ConfigMap{
+		TypeMeta:   typeMeta("v1", "ConfigMap"),
+		ObjectMeta: metav1.ObjectMeta{Name: InventoryName, Namespace: namespace, Labels: managedLabels(inventory.WireKubeVersion)},
+		Data:       map[string]string{"inventory.json": string(data)},
+	}
+	setInstallationID(configMap, inventory.InstallationID)
+	outcome, err := i.applyObject(ctx, configMap, false, inventory.InstallationID, allowLegacyOwnership)
+	if err != nil {
+		return applyOutcome{}, fmt.Errorf("write installation inventory: %w", err)
+	}
+	return outcome, nil
+}
+
+func (i Installer) LoadInventory(ctx context.Context, namespace string) (*Inventory, error) {
+	configMap := &corev1.ConfigMap{}
+	if err := i.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: InventoryName}, configMap); err != nil {
+		return nil, err
+	}
+	inventory := &Inventory{}
+	if err := json.Unmarshal([]byte(configMap.Data["inventory.json"]), inventory); err != nil {
+		return nil, fmt.Errorf("decode installation inventory: %w", err)
+	}
+	return inventory, nil
+}
+
+func (i Installer) Uninstall(ctx context.Context, namespace string, purge bool) (*Inventory, error) {
+	inventory, err := i.LoadInventory(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	for index := len(inventory.Resources) - 1; index >= 0; index-- {
+		resource := inventory.Resources[index]
+		if resource.Preserve {
+			continue
+		}
+		if _, err := i.deleteManagedResource(ctx, resource, inventory.InstallationID); err != nil {
+			return nil, err
+		}
+	}
+	if purge {
+		if err := i.deleteCustomResources(ctx); err != nil {
+			return nil, err
+		}
+		for index := len(inventory.Resources) - 1; index >= 0; index-- {
+			resource := inventory.Resources[index]
+			if resource.Kind != "CustomResourceDefinition" {
+				continue
+			}
+			if _, err := i.deleteManagedResource(ctx, resource, inventory.InstallationID); err != nil {
+				return nil, err
+			}
+		}
+	}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: InventoryName, Namespace: namespace}}
+	if err := i.Client.Delete(ctx, configMap); err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	return inventory, nil
+}
+
+func (i Installer) removeStaleResources(ctx context.Context, previous, current []Resource, installationID string) error {
+	for _, resource := range staleResources(previous, current) {
+		if _, err := i.deleteManagedResource(ctx, resource, installationID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func staleResources(previous, current []Resource) []Resource {
+	currentKeys := make(map[string]struct{}, len(current))
+	for _, resource := range current {
+		currentKeys[resourceIdentity(resource)] = struct{}{}
+	}
+	stale := make([]Resource, 0)
+	for index := len(previous) - 1; index >= 0; index-- {
+		resource := previous[index]
+		if resource.Preserve {
+			continue
+		}
+		if _, exists := currentKeys[resourceIdentity(resource)]; exists {
+			continue
+		}
+		stale = append(stale, resource)
+	}
+	return stale
+}
+
+func (i Installer) deleteManagedResource(ctx context.Context, resource Resource, installationID string) (client.Object, error) {
+	object := objectForResource(resource)
+	err := i.Client.Get(ctx, client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, object)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s %s before deletion: %w", resource.Kind, resourceName(resource), err)
+	}
+	if object.GetLabels()["app.kubernetes.io/managed-by"] != "wirekubectl" {
+		return nil, fmt.Errorf("refusing to delete %s %s because it is not managed by wirekubectl", resource.Kind, resourceName(resource))
+	}
+	if object.GetLabels()[InstallationIDLabel] != installationID {
+		return nil, fmt.Errorf("refusing to delete %s %s because it belongs to installation %q, not %q", resource.Kind, resourceName(resource), object.GetLabels()[InstallationIDLabel], installationID)
+	}
+	object.SetAPIVersion(resource.APIVersion)
+	object.SetKind(resource.Kind)
+	snapshot := object.DeepCopyObject().(client.Object)
+	if err := i.Client.Delete(ctx, object); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("delete %s %s: %w", resource.Kind, resourceName(resource), err)
+	}
+	if resource.Kind == "DaemonSet" && resource.Name == "wirekube-agent" {
+		if err := poll(ctx, time.Second, func() (bool, error) {
+			current := objectForResource(resource)
+			err := i.Client.Get(ctx, client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, current)
+			return apierrors.IsNotFound(err), client.IgnoreNotFound(err)
+		}); err != nil {
+			return nil, fmt.Errorf("wait for agent shutdown before removing RBAC: %w", err)
+		}
+	}
+	return snapshot, nil
+}
+
+func objectForResource(resource Resource) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{}
+	object.SetAPIVersion(resource.APIVersion)
+	object.SetKind(resource.Kind)
+	object.SetNamespace(resource.Namespace)
+	object.SetName(resource.Name)
+	return object
+}
+
+func resourceIdentity(resource Resource) string {
+	return resource.APIVersion + "\x00" + resource.Kind + "\x00" + resource.Namespace + "\x00" + resource.Name
+}
+
+func resourceName(resource Resource) string {
+	if resource.Namespace == "" {
+		return resource.Name
+	}
+	return resource.Namespace + "/" + resource.Name
+}
+
+func (i Installer) deleteCustomResources(ctx context.Context) error {
+	externalPeers := &wirekubev1alpha1.WireKubeExternalPeerList{}
+	if err := i.Client.List(ctx, externalPeers); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	for index := range externalPeers.Items {
+		if err := i.Client.Delete(ctx, &externalPeers.Items[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	gateways := &wirekubev1alpha1.WireKubeGatewayList{}
+	if err := i.Client.List(ctx, gateways); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	for index := range gateways.Items {
+		if err := i.Client.Delete(ctx, &gateways.Items[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	peers := &wirekubev1alpha1.WireKubePeerList{}
+	if err := i.Client.List(ctx, peers); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	for index := range peers.Items {
+		if err := i.Client.Delete(ctx, &peers.Items[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	meshes := &wirekubev1alpha1.WireKubeMeshList{}
+	if err := i.Client.List(ctx, meshes); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	for index := range meshes.Items {
+		if err := i.Client.Delete(ctx, &meshes.Items[index]); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func Manifest(bundle *Bundle) ([]byte, error) {
+	var output []byte
+	objects := make([]runtime.Object, 0, len(bundle.CRDs)+len(bundle.Objects))
+	for _, crd := range bundle.CRDs {
+		objects = append(objects, crd)
+	}
+	objects = append(objects, bundle.Objects...)
+	for index, object := range objects {
+		jsonData, err := json.Marshal(object)
+		if err != nil {
+			return nil, err
+		}
+		yamlData, err := yaml.JSONToYAML(jsonData)
+		if err != nil {
+			return nil, err
+		}
+		if index > 0 {
+			output = append(output, []byte("---\n")...)
+		}
+		output = append(output, yamlData...)
+	}
+	return output, nil
+}
+
+func poll(ctx context.Context, interval time.Duration, condition func() (bool, error)) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		ready, err := condition()
+		if err != nil {
+			return err
+		}
+		if ready {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/install/installer_test.go
+++ b/internal/install/installer_test.go
@@ -1,0 +1,489 @@
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+)
+
+func TestDefaultUninstallPreservesCRDsAndCustomResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, rbacv1.AddToScheme, apiextensionsv1.AddToScheme, wirekubev1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	options := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"}
+	bundle, err := Render(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventory := Inventory{SchemaVersion: SchemaVersion, InstallationID: "installation-1", InstalledAt: time.Now(), UpdatedAt: time.Now(), Options: options, Resources: bundle.Resources}
+	stampBundleInstallation(bundle, inventory.InstallationID)
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: objectMeta(InventoryName, options.Namespace), Data: map[string]string{"inventory.json": string(data)}},
+	}
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(client.Object); ok {
+			objects = append(objects, typed)
+		}
+	}
+	for _, crd := range bundle.CRDs {
+		objects = append(objects, crd)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	if _, err := (Installer{Client: c}).Uninstall(context.Background(), options.Namespace, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, &wirekubev1alpha1.WireKubeMesh{}); err != nil {
+		t.Fatalf("mesh was removed: %v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: bundle.CRDs[0].Name}, &apiextensionsv1.CustomResourceDefinition{}); err != nil {
+		t.Fatalf("CRD was removed: %v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: options.Namespace, Name: "wirekube-agent"}, &appsv1.DaemonSet{}); err == nil {
+		t.Fatal("agent DaemonSet was not removed")
+	}
+}
+
+func TestPurgeDeletesCRDsAndCustomResources(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, rbacv1.AddToScheme, apiextensionsv1.AddToScheme, wirekubev1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	options := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"}
+	bundle, err := Render(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inventory := Inventory{SchemaVersion: SchemaVersion, InstallationID: "installation-1", InstalledAt: time.Now(), UpdatedAt: time.Now(), Options: options, Resources: bundle.Resources}
+	stampBundleInstallation(bundle, inventory.InstallationID)
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: objectMeta(InventoryName, options.Namespace), Data: map[string]string{"inventory.json": string(data)}},
+	}
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(client.Object); ok {
+			objects = append(objects, typed)
+		}
+	}
+	for _, crd := range bundle.CRDs {
+		objects = append(objects, crd)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+	if _, err := (Installer{Client: c}).Uninstall(context.Background(), options.Namespace, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: "default"}, &wirekubev1alpha1.WireKubeMesh{}); err == nil {
+		t.Fatal("mesh custom resource was not purged")
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: bundle.CRDs[0].Name}, &apiextensionsv1.CustomResourceDefinition{}); err == nil {
+		t.Fatal("CRD was not purged")
+	}
+}
+
+func TestInstallIsIdempotentWithSameInventory(t *testing.T) {
+	scheme := installTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &applyTestClient{Client: base, ready: true}
+	options := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", NodeAddresses: "mesh-only", WireKubeVersion: "v1.0.0"}
+	plan := Plan{SchemaVersion: SchemaVersion, Namespace: options.Namespace, Image: options.Image, Relay: options.Relay, MeshCIDR: options.MeshCIDR}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	first, err := (Installer{Client: c}).Apply(ctx, plan, options, "install")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := (Installer{Client: c}).Apply(ctx, plan, options, "install")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.InstallationID == "" || second.InstallationID != first.InstallationID {
+		t.Fatalf("installation IDs: first=%q second=%q", first.InstallationID, second.InstallationID)
+	}
+}
+
+func TestInstallRejectsSecondNamespaceWithoutChangingClusterRBAC(t *testing.T) {
+	scheme := installTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &applyTestClient{Client: base, ready: true}
+	firstOptions := Options{Namespace: "wirekube-a", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", NodeAddresses: "mesh-only", WireKubeVersion: "v1.0.0"}
+	secondOptions := firstOptions
+	secondOptions.Namespace = "wirekube-b"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	first, err := (Installer{Client: c}).Apply(ctx, Plan{}, firstOptions, "install")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = (Installer{Client: c}).Apply(ctx, Plan{}, secondOptions, "install")
+	if err == nil || !strings.Contains(err.Error(), "already installed cluster-wide in namespace wirekube-a") {
+		t.Fatalf("error=%v", err)
+	}
+
+	binding := &rbacv1.ClusterRoleBinding{}
+	if err := base.Get(ctx, client.ObjectKey{Name: "wirekube-agent"}, binding); err != nil {
+		t.Fatal(err)
+	}
+	if len(binding.Subjects) != 1 || binding.Subjects[0].Namespace != firstOptions.Namespace {
+		t.Fatalf("ClusterRoleBinding subjects=%v", binding.Subjects)
+	}
+	if got := binding.Labels[InstallationIDLabel]; got != first.InstallationID {
+		t.Fatalf("installation label=%q, want %q", got, first.InstallationID)
+	}
+}
+
+func TestUpgradeInventoryFailureRestoresPreviousObjects(t *testing.T) {
+	scheme := installTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &applyTestClient{Client: base, ready: true}
+	oldOptions := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", NodeAddresses: "mesh-only", WireKubeVersion: "v1.0.0"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := (Installer{Client: c}).Apply(ctx, Plan{}, oldOptions, "install"); err != nil {
+		t.Fatal(err)
+	}
+
+	newOptions := oldOptions
+	newOptions.Image = "registry.example.test/wirekube@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	c.failPatchName = InventoryName
+	_, err := (Installer{Client: c}).Apply(ctx, Plan{}, newOptions, "upgrade")
+	if err == nil || !strings.Contains(err.Error(), "write installation inventory") {
+		t.Fatalf("error=%v", err)
+	}
+
+	daemonSet := &appsv1.DaemonSet{}
+	if err := base.Get(ctx, types.NamespacedName{Namespace: oldOptions.Namespace, Name: "wirekube-agent"}, daemonSet); err != nil {
+		t.Fatal(err)
+	}
+	if got := daemonSet.Spec.Template.Spec.Containers[0].Image; got != oldOptions.Image {
+		t.Fatalf("agent image=%q, want rolled back image %q", got, oldOptions.Image)
+	}
+	inventory, err := (Installer{Client: base}).LoadInventory(ctx, oldOptions.Namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inventory.Image != oldOptions.Image {
+		t.Fatalf("inventory image=%q, want %q", inventory.Image, oldOptions.Image)
+	}
+}
+
+func TestUpgradeStaleDeleteFailureRestoresInventoryAndDeletedResources(t *testing.T) {
+	scheme := installTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &applyTestClient{Client: base, ready: true}
+	oldOptions := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayLoadBalancer, RelayUDP: true, MeshCIDR: "100.96.0.0/11", NodeAddresses: "mesh-only", WireKubeVersion: "v1.0.0"}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if _, err := (Installer{Client: c}).Apply(ctx, Plan{}, oldOptions, "install"); err != nil {
+		t.Fatal(err)
+	}
+
+	newOptions := oldOptions
+	newOptions.Relay = RelayNone
+	newOptions.RelayUDP = false
+	c.failDeleteName = "wirekube-relay"
+	_, upgradeErr := (Installer{Client: c}).Apply(ctx, Plan{}, newOptions, "upgrade")
+	if upgradeErr == nil || !strings.Contains(upgradeErr.Error(), "remove resources no longer selected") {
+		t.Fatalf("error=%v", upgradeErr)
+	}
+
+	udpService := &corev1.Service{}
+	if err := base.Get(ctx, types.NamespacedName{Namespace: oldOptions.Namespace, Name: "wirekube-relay-udp"}, udpService); err != nil {
+		t.Fatalf("deleted stale Service was not restored after %v: %v", upgradeErr, err)
+	}
+	inventory, err := (Installer{Client: base}).LoadInventory(ctx, oldOptions.Namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inventory.Options.Relay != RelayLoadBalancer || !inventory.Options.RelayUDP {
+		t.Fatalf("inventory options were not rolled back: %+v", inventory.Options)
+	}
+}
+
+func TestFreshInstallCRDTimeoutRollsBackCreatedCRDs(t *testing.T) {
+	scheme := installTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := &applyTestClient{Client: base, ready: false}
+	options := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"}
+	bundle, err := Render(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if _, err := (Installer{Client: c}).Apply(ctx, Plan{}, options, "install"); err == nil {
+		t.Fatal("install unexpectedly succeeded")
+	}
+	for _, crd := range bundle.CRDs {
+		err := base.Get(context.Background(), client.ObjectKey{Name: crd.Name}, &apiextensionsv1.CustomResourceDefinition{})
+		if err == nil {
+			t.Fatalf("created CRD %s was not rolled back", crd.Name)
+		}
+	}
+}
+
+func TestInstallConflictPreservesUnmanagedResourceAndRollsBackNewObjects(t *testing.T) {
+	scheme := installTestScheme(t)
+	unmanaged := &corev1.ServiceAccount{ObjectMeta: objectMeta("wirekube-agent", "wirekube-system")}
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unmanaged).Build()
+	c := &applyTestClient{Client: base, ready: true}
+	options := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"}
+	bundle, err := Render(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = (Installer{Client: c}).Apply(context.Background(), Plan{}, options, "install")
+	if err == nil || !strings.Contains(err.Error(), "not managed by wirekubectl") {
+		t.Fatalf("error=%v", err)
+	}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(unmanaged), &corev1.ServiceAccount{}); err != nil {
+		t.Fatalf("unmanaged resource was removed: %v", err)
+	}
+	for _, crd := range bundle.CRDs {
+		if err := base.Get(context.Background(), client.ObjectKey{Name: crd.Name}, &apiextensionsv1.CustomResourceDefinition{}); err == nil {
+			t.Fatalf("created CRD %s was not rolled back", crd.Name)
+		}
+	}
+}
+
+func TestSameInstallConfigIgnoresTransientFlags(t *testing.T) {
+	left := Options{Namespace: "wirekube-system", Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", NodeAddresses: "mesh-only"}
+	right := left
+	right.Yes = true
+	right.DryRun = true
+	right.Adopt = true
+	right.Timeout = time.Minute
+	if !sameInstallConfig(left, right) {
+		t.Fatal("transient command flags changed the installation identity")
+	}
+	right.Image = "registry.example.test/wirekube@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if sameInstallConfig(left, right) {
+		t.Fatal("different images were treated as the same installation")
+	}
+}
+
+func TestUninstallDeletesResourcesRecordedByInventory(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	resource := Resource{APIVersion: "v1", Kind: "ConfigMap", Namespace: "wirekube-system", Name: "legacy-wirekube-resource"}
+	inventory := Inventory{
+		SchemaVersion:  SchemaVersion,
+		InstallationID: "installation-1",
+		Options:        Options{Namespace: "wirekube-system"},
+		Resources:      []Resource{resource},
+	}
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.ConfigMap{ObjectMeta: managedObjectMeta(resource.Name, resource.Namespace)},
+		&corev1.ConfigMap{ObjectMeta: objectMeta(InventoryName, resource.Namespace), Data: map[string]string{"inventory.json": string(data)}},
+	).Build()
+
+	if _, err := (Installer{Client: c}).Uninstall(context.Background(), resource.Namespace, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, &corev1.ConfigMap{}); err == nil {
+		t.Fatal("resource recorded by the inventory was not deleted")
+	}
+}
+
+func TestUninstallRefusesToDeleteUnmanagedRecordedResource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	resource := Resource{APIVersion: "v1", Kind: "ConfigMap", Namespace: "wirekube-system", Name: "user-owned"}
+	inventory := Inventory{
+		SchemaVersion:  SchemaVersion,
+		InstallationID: "installation-1",
+		Options:        Options{Namespace: resource.Namespace},
+		Resources:      []Resource{resource},
+	}
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.ConfigMap{ObjectMeta: objectMeta(resource.Name, resource.Namespace)},
+		&corev1.ConfigMap{ObjectMeta: objectMeta(InventoryName, resource.Namespace), Data: map[string]string{"inventory.json": string(data)}},
+	).Build()
+
+	_, err = (Installer{Client: c}).Uninstall(context.Background(), resource.Namespace, false)
+	if err == nil || !strings.Contains(err.Error(), "not managed by wirekubectl") {
+		t.Fatalf("error=%v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("unmanaged resource was deleted: %v", err)
+	}
+}
+
+func TestUninstallRefusesResourceOwnedByDifferentInstallation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	resource := Resource{APIVersion: "v1", Kind: "ConfigMap", Namespace: "wirekube-system", Name: "owned-by-another-installation"}
+	inventory := Inventory{
+		SchemaVersion:  SchemaVersion,
+		InstallationID: "installation-2",
+		Options:        Options{Namespace: resource.Namespace},
+		Resources:      []Resource{resource},
+	}
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.ConfigMap{ObjectMeta: managedObjectMeta(resource.Name, resource.Namespace)},
+		&corev1.ConfigMap{ObjectMeta: objectMeta(InventoryName, resource.Namespace), Data: map[string]string{"inventory.json": string(data)}},
+	).Build()
+
+	_, err = (Installer{Client: c}).Uninstall(context.Background(), resource.Namespace, false)
+	if err == nil || !strings.Contains(err.Error(), "belongs to installation") {
+		t.Fatalf("error=%v", err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: resource.Namespace, Name: resource.Name}, &corev1.ConfigMap{}); err != nil {
+		t.Fatalf("resource owned by another installation was deleted: %v", err)
+	}
+}
+
+func TestRemoveStaleResourcesDeletesOnlyResourcesAbsentFromNewPlan(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	stale := Resource{APIVersion: "v1", Kind: "Service", Namespace: "wirekube-system", Name: "wirekube-relay-udp"}
+	retained := Resource{APIVersion: "v1", Kind: "Service", Namespace: "wirekube-system", Name: "wirekube-relay"}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Service{ObjectMeta: managedObjectMeta(stale.Name, stale.Namespace)},
+		&corev1.Service{ObjectMeta: managedObjectMeta(retained.Name, retained.Namespace)},
+	).Build()
+
+	installer := Installer{Client: c}
+	if err := installer.removeStaleResources(context.Background(), []Resource{retained, stale}, []Resource{retained}, "installation-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: stale.Namespace, Name: stale.Name}, &corev1.Service{}); err == nil {
+		t.Fatal("stale resource was not deleted")
+	}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: retained.Namespace, Name: retained.Name}, &corev1.Service{}); err != nil {
+		t.Fatalf("retained resource was deleted: %v", err)
+	}
+}
+
+func objectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: namespace}
+}
+
+func managedObjectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: map[string]string{"app.kubernetes.io/managed-by": "wirekubectl", InstallationIDLabel: "installation-1"}}
+}
+
+func installTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, rbacv1.AddToScheme, apiextensionsv1.AddToScheme, wirekubev1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return scheme
+}
+
+type applyTestClient struct {
+	client.Client
+	ready          bool
+	failPatchName  string
+	failDeleteName string
+}
+
+func (c *applyTestClient) Patch(ctx context.Context, object client.Object, patch client.Patch, options ...client.PatchOption) error {
+	if object.GetName() == c.failPatchName {
+		return fmt.Errorf("injected patch failure for %s", object.GetName())
+	}
+	if patch.Type() != types.ApplyPatchType {
+		return c.Client.Patch(ctx, object, patch, options...)
+	}
+	desired := object.DeepCopyObject().(client.Object)
+	c.setStatus(desired)
+	existing := reflect.New(reflect.TypeOf(desired).Elem()).Interface().(client.Object)
+	err := c.Client.Get(ctx, client.ObjectKeyFromObject(desired), existing)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if err != nil {
+		return c.Client.Create(ctx, desired)
+	}
+	desired.SetResourceVersion(existing.GetResourceVersion())
+	return c.Client.Update(ctx, desired)
+}
+
+func (c *applyTestClient) Delete(ctx context.Context, object client.Object, options ...client.DeleteOption) error {
+	if object.GetName() == c.failDeleteName {
+		return fmt.Errorf("injected delete failure for %s", object.GetName())
+	}
+	return c.Client.Delete(ctx, object, options...)
+}
+
+func (c *applyTestClient) setStatus(object client.Object) {
+	if !c.ready {
+		return
+	}
+	switch typed := object.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		typed.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue}}
+	case *appsv1.DaemonSet:
+		typed.Status.DesiredNumberScheduled = 1
+		typed.Status.UpdatedNumberScheduled = 1
+		typed.Status.NumberReady = 1
+		typed.Status.NumberAvailable = 1
+	case *appsv1.Deployment:
+		typed.Status.UpdatedReplicas = 1
+		typed.Status.ReadyReplicas = 1
+		typed.Status.AvailableReplicas = 1
+	case *wirekubev1alpha1.WireKubeMesh:
+		typed.Status.TotalPeers = 1
+		typed.Status.ReadyPeers = 1
+	case *corev1.Service:
+		if typed.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			typed.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "203.0.113.10"}}
+		}
+	}
+}

--- a/internal/install/plan.go
+++ b/internal/install/plan.go
@@ -1,0 +1,355 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Planner struct {
+	Client         client.Client
+	Discovery      discovery.DiscoveryInterface
+	AccessReviewer AccessReviewer
+}
+
+type AccessRequirement struct {
+	Group     string
+	Resource  string
+	Verb      string
+	Namespace string
+	Name      string
+}
+
+type AccessReviewer interface {
+	Review(context.Context, []AccessRequirement) error
+}
+
+type SelfSubjectAccessReviewer struct {
+	Client client.Client
+}
+
+func (r SelfSubjectAccessReviewer) Review(ctx context.Context, requirements []AccessRequirement) error {
+	var denied []string
+	for _, requirement := range requirements {
+		review := &authorizationv1.SelfSubjectAccessReview{Spec: authorizationv1.SelfSubjectAccessReviewSpec{ResourceAttributes: &authorizationv1.ResourceAttributes{
+			Group: requirement.Group, Resource: requirement.Resource, Verb: requirement.Verb, Namespace: requirement.Namespace, Name: requirement.Name,
+		}}}
+		if err := r.Client.Create(ctx, review); err != nil {
+			return fmt.Errorf("review Kubernetes permission %s %s: %w", requirement.Verb, requirement.Resource, err)
+		}
+		if review.Status.Allowed {
+			continue
+		}
+		target := requirement.Resource
+		if requirement.Group != "" {
+			target += "." + requirement.Group
+		}
+		if requirement.Namespace != "" {
+			target = requirement.Namespace + "/" + target
+		}
+		if requirement.Name != "" {
+			target += "/" + requirement.Name
+		}
+		if review.Status.Reason != "" {
+			target += " (" + review.Status.Reason + ")"
+		}
+		denied = append(denied, requirement.Verb+" "+target)
+	}
+	if len(denied) > 0 {
+		return fmt.Errorf("insufficient Kubernetes permissions: %s", strings.Join(denied, ", "))
+	}
+	return nil
+}
+
+func (p Planner) Build(ctx context.Context, options Options) (Plan, Options, error) {
+	if options.MeshCIDR == "" {
+		options.MeshCIDR = "auto"
+	}
+	if err := options.Normalize(); err != nil {
+		return Plan{}, options, err
+	}
+	if p.AccessReviewer != nil {
+		if err := p.AccessReviewer.Review(ctx, installationAccessRequirements(options)); err != nil {
+			return Plan{}, options, err
+		}
+	}
+	autoMeshCIDR := options.MeshCIDR == "auto"
+	if autoMeshCIDR && options.Yes && !options.DryRun {
+		return Plan{}, options, fmt.Errorf("--mesh-cidr must be explicit for non-interactive installation; automatic selection cannot inspect every VPC, corporate, or node route (use --exclude-cidr during dry-run to evaluate candidates)")
+	}
+	if options.MeshCIDR == "auto" {
+		cidr, err := p.selectMeshCIDR(ctx, options.ExcludeCIDRs)
+		if err != nil {
+			return Plan{}, options, err
+		}
+		options.MeshCIDR = cidr
+	} else {
+		prefix, err := netip.ParsePrefix(options.MeshCIDR)
+		if err != nil {
+			return Plan{}, options, fmt.Errorf("invalid --mesh-cidr %q: %w", options.MeshCIDR, err)
+		}
+		occupied, err := p.occupiedPrefixes(ctx, options.ExcludeCIDRs)
+		if err != nil {
+			return Plan{}, options, err
+		}
+		if conflicts := overlappingPrefixes(prefix.Masked(), occupied); len(conflicts) > 0 {
+			return Plan{}, options, fmt.Errorf("--mesh-cidr %s overlaps observed cluster or local network %s", prefix.Masked(), strings.Join(conflicts, ", "))
+		}
+		options.MeshCIDR = prefix.Masked().String()
+	}
+	bundle, err := Render(options)
+	if err != nil {
+		return Plan{}, options, err
+	}
+	detection, err := p.detect(ctx)
+	if err != nil {
+		return Plan{}, options, err
+	}
+	plan := Plan{
+		SchemaVersion:    SchemaVersion,
+		Context:          options.Context,
+		ClusterServer:    options.ClusterServer,
+		Detection:        detection,
+		WireKubeVersion:  options.WireKubeVersion,
+		Image:            options.Image,
+		Namespace:        options.Namespace,
+		Relay:            options.Relay,
+		RelayEndpoint:    options.RelayEndpoint,
+		RelayUDPEndpoint: options.RelayUDPEndpoint,
+		RelayUDP:         options.RelayUDP,
+		MeshCIDR:         options.MeshCIDR,
+		NodeAddresses:    options.NodeAddresses,
+		Resources:        bundle.Resources,
+		Impact: []string{
+			"privileged host-networked agent Pod on each selected Linux node",
+			"WireGuard interface, host routes, and policy routing rules on each agent node",
+		},
+	}
+	if autoMeshCIDR {
+		plan.Warnings = append(plan.Warnings, "automatic mesh CIDR selection is best effort and cannot inspect every VPC, corporate, or node routing table; review the selected CIDR and provide --exclude-cidr for known routes")
+	}
+	switch options.Relay {
+	case RelayLoadBalancer:
+		plan.Impact = append(plan.Impact, "one public TCP LoadBalancer")
+		plan.Warnings = append(plan.Warnings, "the selected relay creates a public LoadBalancer and may incur provider charges")
+		if options.RelayUDP {
+			plan.Impact = append(plan.Impact, "one separate public UDP LoadBalancer")
+		}
+	case RelayNodePort:
+		plan.Impact = append(plan.Impact, "TCP NodePort 30478 on cluster nodes")
+		if options.RelayUDP {
+			plan.Impact = append(plan.Impact, "UDP NodePort 30479 on cluster nodes")
+		}
+	case RelayExternal:
+		plan.Warnings = append(plan.Warnings, "the external relay endpoint is not provisioned or owned by this installation")
+		if options.RelayUDPEndpoint == "" {
+			plan.Warnings = append(plan.Warnings, "external peer invites remain Pending until --relay-udp-endpoint is configured")
+		}
+	case RelayNone:
+		plan.Warnings = append(plan.Warnings, "peers that cannot establish a direct path will remain disconnected")
+	}
+	return plan, options, nil
+}
+
+func installationAccessRequirements(options Options) []AccessRequirement {
+	requirements := []AccessRequirement{
+		{Resource: "nodes", Verb: "list"},
+		{Resource: "services", Verb: "list"},
+		{Resource: "pods", Verb: "list", Namespace: "kube-system"},
+		{Resource: "configmaps", Verb: "list"},
+		{Resource: "namespaces", Verb: "get", Name: options.Namespace},
+		{Resource: "namespaces", Verb: "patch", Name: options.Namespace},
+		{Resource: "serviceaccounts", Verb: "get", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Resource: "serviceaccounts", Verb: "patch", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Resource: "serviceaccounts", Verb: "delete", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Resource: "configmaps", Verb: "get", Namespace: options.Namespace, Name: InventoryName},
+		{Resource: "configmaps", Verb: "patch", Namespace: options.Namespace, Name: InventoryName},
+		{Resource: "configmaps", Verb: "delete", Namespace: options.Namespace, Name: InventoryName},
+		{Group: "apps", Resource: "daemonsets", Verb: "get", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Group: "apps", Resource: "daemonsets", Verb: "patch", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Group: "apps", Resource: "daemonsets", Verb: "delete", Namespace: options.Namespace, Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Verb: "get", Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Verb: "patch", Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Verb: "delete", Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Verb: "get", Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Verb: "patch", Name: "wirekube-agent"},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings", Verb: "delete", Name: "wirekube-agent"},
+		{Group: "wirekube.io", Resource: "wirekubemeshes", Verb: "get", Name: "default"},
+		{Group: "wirekube.io", Resource: "wirekubemeshes", Verb: "patch", Name: "default"},
+	}
+	for _, name := range []string{"wirekubemeshes.wirekube.io", "wirekubepeers.wirekube.io", "wirekubegateways.wirekube.io", "wirekubeexternalpeers.wirekube.io"} {
+		requirements = append(requirements,
+			AccessRequirement{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions", Verb: "get", Name: name},
+			AccessRequirement{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions", Verb: "patch", Name: name},
+		)
+	}
+	if options.Relay == RelayLoadBalancer || options.Relay == RelayNodePort {
+		requirements = append(requirements,
+			AccessRequirement{Group: "apps", Resource: "deployments", Verb: "get", Namespace: options.Namespace, Name: "wirekube-relay"},
+			AccessRequirement{Group: "apps", Resource: "deployments", Verb: "patch", Namespace: options.Namespace, Name: "wirekube-relay"},
+			AccessRequirement{Group: "apps", Resource: "deployments", Verb: "delete", Namespace: options.Namespace, Name: "wirekube-relay"},
+		)
+		for _, name := range []string{"wirekube-relay-control", "wirekube-relay", "wirekube-relay-udp"} {
+			requirements = append(requirements,
+				AccessRequirement{Resource: "services", Verb: "get", Namespace: options.Namespace, Name: name},
+				AccessRequirement{Resource: "services", Verb: "patch", Namespace: options.Namespace, Name: name},
+				AccessRequirement{Resource: "services", Verb: "delete", Namespace: options.Namespace, Name: name},
+			)
+		}
+	}
+	return requirements
+}
+
+func (p Planner) detect(ctx context.Context) (Detection, error) {
+	detection := Detection{Provider: "unknown", CNI: "unknown"}
+	if p.Discovery != nil {
+		version, err := p.Discovery.ServerVersion()
+		if err != nil {
+			return detection, fmt.Errorf("discover Kubernetes version: %w", err)
+		}
+		detection.KubernetesVersion = version.GitVersion
+	}
+	var nodes corev1.NodeList
+	if err := p.Client.List(ctx, &nodes); err != nil {
+		return detection, fmt.Errorf("list Nodes: %w", err)
+	}
+	for _, node := range nodes.Items {
+		providerID := strings.ToLower(node.Spec.ProviderID)
+		switch {
+		case strings.HasPrefix(providerID, "aws://"):
+			detection.Provider = "aws"
+		case strings.HasPrefix(providerID, "gce://"):
+			detection.Provider = "gcp"
+		case strings.HasPrefix(providerID, "azure://"):
+			detection.Provider = "azure"
+		case strings.HasPrefix(providerID, "oci://"):
+			detection.Provider = "oci"
+		}
+	}
+	var pods corev1.PodList
+	if err := p.Client.List(ctx, &pods, client.InNamespace("kube-system")); err == nil {
+		for _, pod := range pods.Items {
+			name := strings.ToLower(pod.Name)
+			switch {
+			case strings.Contains(name, "cilium"):
+				detection.CNI = "cilium"
+			case strings.Contains(name, "calico") && detection.CNI == "unknown":
+				detection.CNI = "calico"
+			case strings.Contains(name, "flannel") && detection.CNI == "unknown":
+				detection.CNI = "flannel"
+			}
+		}
+	}
+	return detection, nil
+}
+
+func (p Planner) selectMeshCIDR(ctx context.Context, excluded []string) (string, error) {
+	occupied, err := p.occupiedPrefixes(ctx, excluded)
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{"100.96.0.0/11", "100.64.0.0/11", "10.240.0.0/16", "172.30.0.0/16", "198.18.0.0/16"}
+	for _, candidate := range candidates {
+		prefix := netip.MustParsePrefix(candidate)
+		if !overlapsAny(prefix, occupied) {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no safe mesh CIDR candidate remains; specify --mesh-cidr and use --exclude-cidr for known routes")
+}
+
+func (p Planner) occupiedPrefixes(ctx context.Context, excluded []string) ([]netip.Prefix, error) {
+	var occupied []netip.Prefix
+	add := func(value string) {
+		if prefix, err := netip.ParsePrefix(value); err == nil {
+			occupied = append(occupied, prefix.Masked())
+		} else if addr, err := netip.ParseAddr(value); err == nil {
+			bits := 128
+			if addr.Is4() {
+				bits = 32
+			}
+			occupied = append(occupied, netip.PrefixFrom(addr, bits))
+		}
+	}
+	for _, value := range excluded {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --exclude-cidr %q: %w", value, err)
+		}
+		occupied = append(occupied, prefix.Masked())
+	}
+	var nodes corev1.NodeList
+	if err := p.Client.List(ctx, &nodes); err != nil {
+		return nil, fmt.Errorf("list Nodes for mesh CIDR selection: %w", err)
+	}
+	for _, node := range nodes.Items {
+		for _, cidr := range node.Spec.PodCIDRs {
+			add(cidr)
+		}
+		for _, address := range node.Status.Addresses {
+			add(address.Address)
+		}
+	}
+	var services corev1.ServiceList
+	if err := p.Client.List(ctx, &services); err != nil {
+		return nil, fmt.Errorf("list Services for mesh CIDR selection: %w", err)
+	}
+	for _, service := range services.Items {
+		for _, ip := range service.Spec.ClusterIPs {
+			add(ip)
+		}
+		for _, ingress := range service.Status.LoadBalancer.Ingress {
+			add(ingress.IP)
+		}
+	}
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		addresses, _ := iface.Addrs()
+		for _, address := range addresses {
+			add(address.String())
+		}
+	}
+	sort.Slice(occupied, func(i, j int) bool { return occupied[i].String() < occupied[j].String() })
+	return occupied, nil
+}
+
+func overlapsAny(candidate netip.Prefix, occupied []netip.Prefix) bool {
+	for _, prefix := range occupied {
+		if candidate.Addr().BitLen() != prefix.Addr().BitLen() {
+			continue
+		}
+		if candidate.Contains(prefix.Addr()) || prefix.Contains(candidate.Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+func overlappingPrefixes(candidate netip.Prefix, occupied []netip.Prefix) []string {
+	conflicts := make([]string, 0)
+	seen := map[string]struct{}{}
+	for _, prefix := range occupied {
+		if candidate.Addr().BitLen() != prefix.Addr().BitLen() {
+			continue
+		}
+		if !candidate.Contains(prefix.Addr()) && !prefix.Contains(candidate.Addr()) {
+			continue
+		}
+		value := prefix.String()
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		conflicts = append(conflicts, value)
+	}
+	sort.Strings(conflicts)
+	return conflicts
+}

--- a/internal/install/render.go
+++ b/internal/install/render.go
@@ -1,0 +1,289 @@
+package install
+
+import (
+	"fmt"
+	"io/fs"
+	"net"
+	"sort"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/yaml"
+
+	crdassets "github.com/inerplat/wirekube/config/crd"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+)
+
+type Bundle struct {
+	CRDs      []*apiextensionsv1.CustomResourceDefinition
+	Objects   []runtime.Object
+	Resources []Resource
+}
+
+func Render(options Options) (*Bundle, error) {
+	if err := options.Normalize(); err != nil {
+		return nil, err
+	}
+	crds, err := embeddedCRDs()
+	if err != nil {
+		return nil, err
+	}
+	labels := managedLabels(options.WireKubeVersion)
+	for _, crd := range crds {
+		crd.Labels = copyLabels(labels)
+	}
+	objects := []runtime.Object{
+		&corev1.Namespace{TypeMeta: typeMeta("v1", "Namespace"), ObjectMeta: metav1.ObjectMeta{Name: options.Namespace, Labels: labels}},
+		agentServiceAccount(options, labels),
+		agentClusterRole(options, labels),
+		agentClusterRoleBinding(options, labels),
+		meshObject(options),
+	}
+	if options.Relay == RelayLoadBalancer || options.Relay == RelayNodePort {
+		objects = append(objects, relayDeployment(options, labels), relayControlService(options, labels), relayTCPService(options, labels))
+		if options.RelayUDP {
+			objects = append(objects, relayUDPService(options, labels))
+		}
+	}
+	objects = append(objects, agentDaemonSet(options, labels))
+
+	bundle := &Bundle{CRDs: crds, Objects: objects}
+	for _, crd := range crds {
+		bundle.Resources = append(bundle.Resources, resourceFor(crd, true))
+	}
+	for _, object := range objects {
+		preserve := false
+		switch object.(type) {
+		case *corev1.Namespace, *wirekubev1alpha1.WireKubeMesh:
+			preserve = true
+		}
+		bundle.Resources = append(bundle.Resources, resourceFor(object.(metav1.Object), preserve))
+	}
+	return bundle, nil
+}
+
+func embeddedCRDs() ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	entries, err := fs.ReadDir(crdassets.Files, ".")
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	var crds []*apiextensionsv1.CustomResourceDefinition
+	for _, entry := range entries {
+		if entry.IsDir() || len(entry.Name()) < 5 || entry.Name()[len(entry.Name())-5:] != ".yaml" {
+			continue
+		}
+		data, err := crdassets.Files.ReadFile(entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := yaml.Unmarshal(data, crd); err != nil {
+			return nil, fmt.Errorf("decode embedded CRD %s: %w", entry.Name(), err)
+		}
+		crds = append(crds, crd)
+	}
+	if len(crds) == 0 {
+		return nil, fmt.Errorf("no embedded CRDs found")
+	}
+	return crds, nil
+}
+
+func managedLabels(version string) map[string]string {
+	if version == "" {
+		version = "dev"
+	}
+	return map[string]string{
+		"app.kubernetes.io/name":       "wirekube",
+		"app.kubernetes.io/part-of":    "wirekube",
+		"app.kubernetes.io/managed-by": "wirekubectl",
+		"app.kubernetes.io/version":    version,
+	}
+}
+
+func agentServiceAccount(options Options, labels map[string]string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{TypeMeta: typeMeta("v1", "ServiceAccount"), ObjectMeta: metav1.ObjectMeta{Name: "wirekube-agent", Namespace: options.Namespace, Labels: labels}}
+}
+
+func agentClusterRole(options Options, labels map[string]string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   typeMeta(rbacv1.SchemeGroupVersion.String(), "ClusterRole"),
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekube-agent", Labels: labels},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"nodes", "services"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "patch"}},
+			{APIGroups: []string{"wirekube.io"}, Resources: []string{"wirekubepeers"}, Verbs: []string{"get", "list", "create", "patch", "update", "delete", "watch"}},
+			{APIGroups: []string{"wirekube.io"}, Resources: []string{"wirekubepeers/status", "wirekubemeshes/status", "wirekubegateways/status", "wirekubeexternalpeers/status"}, Verbs: []string{"get", "patch", "update"}},
+			{APIGroups: []string{"wirekube.io"}, Resources: []string{"wirekubemeshes", "wirekubegateways"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{"wirekube.io"}, Resources: []string{"wirekubeexternalpeers"}, Verbs: []string{"get", "list", "watch", "update", "delete"}},
+			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"create", "patch"}},
+		},
+	}
+}
+
+func agentClusterRoleBinding(options Options, labels map[string]string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta:   typeMeta(rbacv1.SchemeGroupVersion.String(), "ClusterRoleBinding"),
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekube-agent", Labels: labels},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "wirekube-agent"},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "wirekube-agent", Namespace: options.Namespace}},
+	}
+}
+
+func agentDaemonSet(options Options, labels map[string]string) *appsv1.DaemonSet {
+	componentLabels := copyLabels(labels)
+	componentLabels["app.kubernetes.io/component"] = "agent"
+	selectorLabels := map[string]string{"app.kubernetes.io/name": "wirekube-agent"}
+	podLabels := copyLabels(selectorLabels)
+	podLabels["app.kubernetes.io/component"] = "agent"
+	podLabels["app.kubernetes.io/part-of"] = "wirekube"
+	podLabels["app.kubernetes.io/managed-by"] = "wirekubectl"
+	return &appsv1.DaemonSet{
+		TypeMeta:   typeMeta(appsv1.SchemeGroupVersion.String(), "DaemonSet"),
+		ObjectMeta: metav1.ObjectMeta{Name: "wirekube-agent", Namespace: options.Namespace, Labels: componentLabels},
+		Spec: appsv1.DaemonSetSpec{
+			Selector:       &metav1.LabelSelector{MatchLabels: selectorLabels},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType, RollingUpdate: &appsv1.RollingUpdateDaemonSet{MaxUnavailable: intOrStringPtr(intstr.FromInt32(1))}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: podLabels},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:            "wirekube-agent",
+					HostNetwork:                   true,
+					DNSPolicy:                     corev1.DNSDefault,
+					PriorityClassName:             "system-node-critical",
+					TerminationGracePeriodSeconds: int64Ptr(30),
+					Tolerations:                   []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+					Affinity: &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{{MatchExpressions: []corev1.NodeSelectorRequirement{
+							{Key: "kubernetes.io/os", Operator: corev1.NodeSelectorOpIn, Values: []string{"linux"}},
+							{Key: "wirekube.io/proxy-node", Operator: corev1.NodeSelectorOpNotIn, Values: []string{"true"}},
+						}}},
+					}}},
+					Containers: []corev1.Container{{
+						Name:            "agent",
+						Image:           options.Image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command:         []string{"wirekube-agent"},
+						Args:            []string{"--node-name=$(NODE_NAME)"},
+						Env: []corev1.EnvVar{
+							{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+							{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
+							{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
+							{Name: "WIREKUBE_INTERFACE", Value: "wire_kube"},
+							{Name: "WIREKUBE_RELAY_TOKEN_FILE", Value: "/var/run/secrets/wirekube-relay/token"},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:      boolPtr(true),
+							AppArmorProfile: &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined},
+							Capabilities:    &corev1.Capabilities{Add: []corev1.Capability{"NET_ADMIN", "SYS_MODULE"}},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "wireguard-keys", MountPath: "/var/lib/wirekube"},
+							{Name: "host-proc-sys-net", MountPath: "/host/proc/sys/net"},
+							{Name: "dev-net-tun", MountPath: "/dev/net/tun"},
+							{Name: "relay-token", MountPath: "/var/run/secrets/wirekube-relay", ReadOnly: true},
+						},
+					}},
+					Volumes: []corev1.Volume{
+						{Name: "wireguard-keys", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/wirekube", Type: hostPathTypePtr(corev1.HostPathDirectoryOrCreate)}}},
+						{Name: "host-proc-sys-net", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/proc/sys/net", Type: hostPathTypePtr(corev1.HostPathDirectory)}}},
+						{Name: "dev-net-tun", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/dev/net/tun", Type: hostPathTypePtr(corev1.HostPathCharDev)}}},
+						{Name: "relay-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token", Audience: "wirekube-relay", ExpirationSeconds: int64Ptr(3600)}}}}}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func relayDeployment(options Options, labels map[string]string) *appsv1.Deployment {
+	replicas := int32(1)
+	componentLabels := copyLabels(labels)
+	componentLabels["app.kubernetes.io/component"] = "relay"
+	return &appsv1.Deployment{
+		TypeMeta: typeMeta(appsv1.SchemeGroupVersion.String(), "Deployment"), ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay", Namespace: options.Namespace, Labels: componentLabels},
+		Spec: appsv1.DeploymentSpec{Replicas: &replicas, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "wirekube-relay"}}, Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app.kubernetes.io/name": "wirekube-relay", "app.kubernetes.io/component": "relay", "app.kubernetes.io/part-of": "wirekube", "app.kubernetes.io/managed-by": "wirekubectl"}}, Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "relay", Image: options.Image, Command: []string{"wirekube-relay"}, Args: relayArgs(options), Ports: []corev1.ContainerPort{{Name: "relay-tcp", ContainerPort: 3478, Protocol: corev1.ProtocolTCP}, {Name: "relay-udp", ContainerPort: 3478, Protocol: corev1.ProtocolUDP}}}}}}},
+	}
+}
+
+func relayArgs(options Options) []string {
+	args := []string{"--addr=:3478"}
+	if options.RelayUDP {
+		args = append(args, "--external-wg-addr=:3478")
+	}
+	return args
+}
+
+func relayControlService(options Options, labels map[string]string) *corev1.Service {
+	return &corev1.Service{TypeMeta: typeMeta("v1", "Service"), ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay-control", Namespace: options.Namespace, Labels: labels}, Spec: corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Selector: map[string]string{"app.kubernetes.io/name": "wirekube-relay"}, Ports: []corev1.ServicePort{{Name: "relay-control", Port: 3478, TargetPort: intstr.FromInt32(3478), Protocol: corev1.ProtocolTCP}}}}
+}
+
+func relayTCPService(options Options, labels map[string]string) *corev1.Service {
+	serviceType := corev1.ServiceTypeLoadBalancer
+	port := corev1.ServicePort{Name: "relay-tcp", Port: 3478, TargetPort: intstr.FromInt32(3478), Protocol: corev1.ProtocolTCP}
+	if options.Relay == RelayNodePort {
+		serviceType = corev1.ServiceTypeNodePort
+		port.NodePort = 30478
+	}
+	return &corev1.Service{TypeMeta: typeMeta("v1", "Service"), ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay", Namespace: options.Namespace, Labels: labels}, Spec: corev1.ServiceSpec{Type: serviceType, Selector: map[string]string{"app.kubernetes.io/name": "wirekube-relay"}, Ports: []corev1.ServicePort{port}}}
+}
+
+func relayUDPService(options Options, labels map[string]string) *corev1.Service {
+	serviceType := corev1.ServiceTypeLoadBalancer
+	port := corev1.ServicePort{Name: "relay-udp", Port: 3478, TargetPort: intstr.FromInt32(3478), Protocol: corev1.ProtocolUDP}
+	if options.Relay == RelayNodePort {
+		serviceType = corev1.ServiceTypeNodePort
+		port.NodePort = 30479
+	}
+	return &corev1.Service{TypeMeta: typeMeta("v1", "Service"), ObjectMeta: metav1.ObjectMeta{Name: "wirekube-relay-udp", Namespace: options.Namespace, Labels: labels}, Spec: corev1.ServiceSpec{Type: serviceType, Selector: map[string]string{"app.kubernetes.io/name": "wirekube-relay"}, Ports: []corev1.ServicePort{port}}}
+}
+
+func meshObject(options Options) *wirekubev1alpha1.WireKubeMesh {
+	mesh := &wirekubev1alpha1.WireKubeMesh{TypeMeta: typeMeta(wirekubev1alpha1.GroupVersion.String(), "WireKubeMesh"), ObjectMeta: metav1.ObjectMeta{Name: "default", Labels: managedLabels(options.WireKubeVersion)}, Spec: wirekubev1alpha1.WireKubeMeshSpec{ListenPort: 51820, InterfaceName: "wire_kube", MTU: 1420, MeshCIDR: options.MeshCIDR, STUNServers: []string{"stun:stun.cloudflare.com:3478", "stun:stun.l.google.com:19302"}}}
+	if options.NodeAddresses == "internal-ip" {
+		mesh.Spec.AutoAllowedIPs = &wirekubev1alpha1.AutoAllowedIPsSpec{IncludeNodeInternalIP: true}
+	}
+	switch options.Relay {
+	case RelayNone:
+		mesh.Spec.Relay = nil
+	case RelayLoadBalancer:
+		mesh.Spec.Relay = &wirekubev1alpha1.RelaySpec{Mode: "auto", Provider: "managed", Managed: &wirekubev1alpha1.ManagedRelaySpec{Replicas: 1, ServiceType: string(corev1.ServiceTypeLoadBalancer), Port: 3478, Image: options.Image}}
+	case RelayNodePort:
+		external := &wirekubev1alpha1.ExternalRelaySpec{ControlEndpoint: options.RelayEndpoint, Transport: "tcp"}
+		if options.RelayUDP {
+			host, _, _ := net.SplitHostPort(options.RelayEndpoint)
+			external.Endpoint = net.JoinHostPort(host, "30479")
+		}
+		mesh.Spec.Relay = &wirekubev1alpha1.RelaySpec{Mode: "auto", Provider: "external", External: external}
+	case RelayExternal:
+		mesh.Spec.Relay = &wirekubev1alpha1.RelaySpec{Mode: "auto", Provider: "external", External: &wirekubev1alpha1.ExternalRelaySpec{Endpoint: options.RelayUDPEndpoint, ControlEndpoint: options.RelayEndpoint, Transport: "tcp"}}
+	}
+	return mesh
+}
+
+func typeMeta(apiVersion, kind string) metav1.TypeMeta {
+	return metav1.TypeMeta{APIVersion: apiVersion, Kind: kind}
+}
+func boolPtr(v bool) *bool                                       { return &v }
+func int64Ptr(v int64) *int64                                    { return &v }
+func intOrStringPtr(v intstr.IntOrString) *intstr.IntOrString    { return &v }
+func hostPathTypePtr(v corev1.HostPathType) *corev1.HostPathType { return &v }
+
+func copyLabels(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func resourceFor(object metav1.Object, preserve bool) Resource {
+	gkv := object.(runtime.Object).GetObjectKind().GroupVersionKind()
+	return Resource{APIVersion: gkv.GroupVersion().String(), Kind: gkv.Kind, Namespace: object.GetNamespace(), Name: object.GetName(), Preserve: preserve}
+}

--- a/internal/install/render_test.go
+++ b/internal/install/render_test.go
@@ -1,0 +1,286 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+)
+
+const testImage = "registry.example.test/wirekube@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestOptionsRequireExplicitRelayForNonInteractiveInstall(t *testing.T) {
+	options := Options{Image: testImage, Yes: true}
+	if err := options.Normalize(); err == nil || !strings.Contains(err.Error(), "--relay must be specified") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestOptionsRequireImageDigest(t *testing.T) {
+	options := Options{Image: "registry.example.test/wirekube:v1", Relay: RelayNone}
+	if err := options.Normalize(); err == nil || !strings.Contains(err.Error(), "pinned by digest") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestOptionsRejectNonNumericRelayEndpointPort(t *testing.T) {
+	options := Options{Image: testImage, Relay: RelayExternal, RelayEndpoint: "relay.example.test:https"}
+	if err := options.Normalize(); err == nil || !strings.Contains(err.Error(), "port must be between 1 and 65535") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestRenderUsesPortableDefaultsAndSeparateRelayServices(t *testing.T) {
+	bundle, err := Render(Options{Image: testImage, Relay: RelayLoadBalancer, RelayUDP: true, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := Manifest(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(manifest)
+	for _, forbidden := range []string{"eks.amazonaws.com/nodegroup", "admin-web", ":v0.0."} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("manifest contains %q", forbidden)
+		}
+	}
+	if !strings.Contains(text, testImage) {
+		t.Fatal("manifest does not contain the pinned image")
+	}
+	services := map[string][]corev1.ServicePort{}
+	for _, object := range bundle.Objects {
+		if service, ok := object.(*corev1.Service); ok {
+			services[service.Name] = service.Spec.Ports
+		}
+	}
+	if len(services["wirekube-relay"]) != 1 || services["wirekube-relay"][0].Protocol != corev1.ProtocolTCP {
+		t.Fatalf("TCP relay service=%v", services["wirekube-relay"])
+	}
+	if len(services["wirekube-relay-udp"]) != 1 || services["wirekube-relay-udp"][0].Protocol != corev1.ProtocolUDP {
+		t.Fatalf("UDP relay service=%v", services["wirekube-relay-udp"])
+	}
+}
+
+func TestNodePortUDPUsesSeparateDataAndControlEndpoints(t *testing.T) {
+	bundle, err := Render(Options{Image: testImage, Relay: RelayNodePort, RelayEndpoint: "[2001:db8::10]:30478", RelayUDP: true, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mesh *wirekubev1alpha1.WireKubeMesh
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(*wirekubev1alpha1.WireKubeMesh); ok {
+			mesh = typed
+			break
+		}
+	}
+	if mesh == nil || mesh.Spec.Relay == nil || mesh.Spec.Relay.External == nil {
+		t.Fatal("external relay configuration was not rendered")
+	}
+	if mesh.Spec.Relay.External.ControlEndpoint != "[2001:db8::10]:30478" {
+		t.Fatalf("controlEndpoint=%q", mesh.Spec.Relay.External.ControlEndpoint)
+	}
+	if mesh.Spec.Relay.External.Endpoint != "[2001:db8::10]:30479" {
+		t.Fatalf("endpoint=%q", mesh.Spec.Relay.External.Endpoint)
+	}
+}
+
+func TestNodePortTCPOnlyDoesNotAdvertiseRawWireGuardEndpoint(t *testing.T) {
+	bundle, err := Render(Options{Image: testImage, Relay: RelayNodePort, RelayEndpoint: "203.0.113.10:30478", MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mesh *wirekubev1alpha1.WireKubeMesh
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(*wirekubev1alpha1.WireKubeMesh); ok {
+			mesh = typed
+			break
+		}
+	}
+	if mesh == nil || mesh.Spec.Relay == nil || mesh.Spec.Relay.External == nil {
+		t.Fatal("external relay configuration was not rendered")
+	}
+	if got := mesh.Spec.Relay.External.ControlEndpoint; got != "203.0.113.10:30478" {
+		t.Fatalf("controlEndpoint=%q", got)
+	}
+	if got := mesh.Spec.Relay.External.Endpoint; got != "" {
+		t.Fatalf("endpoint=%q, want empty without UDP", got)
+	}
+}
+
+func TestExternalRelaySeparatesControlAndUDPEndpoints(t *testing.T) {
+	bundle, err := Render(Options{Image: testImage, Relay: RelayExternal, RelayEndpoint: "relay.example.test:443", RelayUDPEndpoint: "wg.example.test:51820", MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mesh *wirekubev1alpha1.WireKubeMesh
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(*wirekubev1alpha1.WireKubeMesh); ok {
+			mesh = typed
+			break
+		}
+	}
+	if mesh == nil || mesh.Spec.Relay == nil || mesh.Spec.Relay.External == nil {
+		t.Fatal("external relay configuration was not rendered")
+	}
+	if got := mesh.Spec.Relay.External.ControlEndpoint; got != "relay.example.test:443" {
+		t.Fatalf("controlEndpoint=%q", got)
+	}
+	if got := mesh.Spec.Relay.External.Endpoint; got != "wg.example.test:51820" {
+		t.Fatalf("endpoint=%q", got)
+	}
+}
+
+func TestDefaultAgentRBACDoesNotGrantAdministrativeCreate(t *testing.T) {
+	bundle, err := Render(Options{Image: testImage, Relay: RelayNone, MeshCIDR: "100.96.0.0/11", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var role *rbacv1.ClusterRole
+	for _, object := range bundle.Objects {
+		if typed, ok := object.(*rbacv1.ClusterRole); ok && typed.Name == "wirekube-agent" {
+			role = typed
+			break
+		}
+	}
+	if role == nil {
+		t.Fatal("agent ClusterRole was not rendered")
+	}
+	for _, rule := range role.Rules {
+		for _, resource := range rule.Resources {
+			if resource != "wirekubemeshes" && resource != "wirekubegateways" && resource != "wirekubeexternalpeers" {
+				continue
+			}
+			for _, verb := range rule.Verbs {
+				if verb == "create" {
+					t.Fatalf("default agent role grants create on %s: %v", resource, rule.Verbs)
+				}
+			}
+		}
+	}
+}
+
+func TestPlannerAvoidsOccupiedCIDRsWithoutMutation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: corev1.NodeSpec{PodCIDR: "100.96.0.0/11", PodCIDRs: []string{"100.96.0.0/11"}}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kubernetes", Namespace: "default"}, Spec: corev1.ServiceSpec{ClusterIP: "10.96.0.1", ClusterIPs: []string{"10.96.0.1"}}},
+	).Build()
+	plan, normalized, err := (Planner{Client: client}).Build(context.Background(), Options{Image: testImage, Relay: RelayNone, MeshCIDR: "auto", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized.MeshCIDR == "100.96.0.0/11" || plan.MeshCIDR == "100.96.0.0/11" {
+		t.Fatalf("selected occupied CIDR: %s", normalized.MeshCIDR)
+	}
+	var namespaces corev1.NamespaceList
+	if err := client.List(context.Background(), &namespaces); err != nil {
+		t.Fatal(err)
+	}
+	if len(namespaces.Items) != 0 {
+		t.Fatalf("planning mutated the cluster: %v", namespaces.Items)
+	}
+}
+
+func TestPlannerRequiresExplicitMeshCIDRForNonInteractiveInstall(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	_, _, err := (Planner{Client: c}).Build(context.Background(), Options{Image: testImage, Relay: RelayNone, MeshCIDR: "auto", Yes: true, WireKubeVersion: "v1.0.0"})
+	if err == nil || !strings.Contains(err.Error(), "--mesh-cidr must be explicit") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestPlannerAllowsAutoMeshCIDRForNonMutatingDryRunWithWarning(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plan, _, err := (Planner{Client: c}).Build(context.Background(), Options{Image: testImage, Relay: RelayNone, MeshCIDR: "auto", Yes: true, DryRun: true, WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, warning := range plan.Warnings {
+		if strings.Contains(warning, "best effort") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warnings=%v", plan.Warnings)
+	}
+}
+
+func TestPlannerRejectsExplicitMeshCIDROverlap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: corev1.NodeSpec{PodCIDR: "198.18.0.0/24", PodCIDRs: []string{"198.18.0.0/24"}}},
+	).Build()
+
+	_, _, err := (Planner{Client: c}).Build(context.Background(), Options{Image: testImage, Relay: RelayNone, MeshCIDR: "198.18.0.0/16", WireKubeVersion: "v1.0.0"})
+	if err == nil || !strings.Contains(err.Error(), "overlaps observed cluster or local network") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestPlannerWarnsAboutPublicLoadBalancerCost(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	plan, _, err := (Planner{Client: c}).Build(context.Background(), Options{Image: testImage, Relay: RelayLoadBalancer, MeshCIDR: "203.0.113.0/24", WireKubeVersion: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Warnings) == 0 || !strings.Contains(plan.Warnings[0], "provider charges") {
+		t.Fatalf("warnings=%v", plan.Warnings)
+	}
+}
+
+func TestPlannerFailsWhenAccessPreflightIsDenied(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reviewer := &testAccessReviewer{err: fmt.Errorf("insufficient Kubernetes permissions: patch deployments.apps")}
+	_, _, err := (Planner{Client: c, AccessReviewer: reviewer}).Build(context.Background(), Options{Image: testImage, Relay: RelayNone, MeshCIDR: "203.0.113.0/24", WireKubeVersion: "v1.0.0"})
+	if err == nil || !strings.Contains(err.Error(), "insufficient Kubernetes permissions") {
+		t.Fatalf("error=%v", err)
+	}
+	if !reviewer.called {
+		t.Fatal("access reviewer was not called")
+	}
+}
+
+type testAccessReviewer struct {
+	called bool
+	err    error
+}
+
+func (r *testAccessReviewer) Review(_ context.Context, requirements []AccessRequirement) error {
+	r.called = true
+	if len(requirements) == 0 {
+		return fmt.Errorf("no access requirements were provided")
+	}
+	return r.err
+}

--- a/internal/install/types.go
+++ b/internal/install/types.go
@@ -1,0 +1,171 @@
+package install
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var digestPattern = regexp.MustCompile(`@sha256:[a-fA-F0-9]{64}$`)
+
+const (
+	SchemaVersion       = "v1alpha1"
+	FieldManager        = "wirekubectl.wirekube.io"
+	InventoryName       = "wirekube-installation"
+	InstallationIDLabel = "wirekube.io/installation-id"
+
+	RelayNone         = "none"
+	RelayLoadBalancer = "load-balancer"
+	RelayNodePort     = "node-port"
+	RelayExternal     = "external"
+)
+
+type Options struct {
+	Namespace        string
+	Image            string
+	Relay            string
+	RelayEndpoint    string
+	RelayUDPEndpoint string
+	RelayUDP         bool
+	MeshCIDR         string
+	NodeAddresses    string
+	ExcludeCIDRs     []string
+	Yes              bool
+	DryRun           bool
+	Adopt            bool
+	Timeout          time.Duration
+	Context          string
+	ClusterServer    string
+	WireKubeVersion  string
+}
+
+type Detection struct {
+	KubernetesVersion string `json:"kubernetesVersion"`
+	Provider          string `json:"provider"`
+	CNI               string `json:"cni"`
+}
+
+type Resource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace,omitempty"`
+	Name       string `json:"name"`
+	Preserve   bool   `json:"preserve,omitempty"`
+}
+
+type Plan struct {
+	SchemaVersion    string     `json:"schemaVersion"`
+	Context          string     `json:"context"`
+	ClusterServer    string     `json:"clusterServer"`
+	Detection        Detection  `json:"detection"`
+	WireKubeVersion  string     `json:"wireKubeVersion"`
+	Image            string     `json:"image"`
+	Namespace        string     `json:"namespace"`
+	Relay            string     `json:"relay"`
+	RelayEndpoint    string     `json:"relayEndpoint,omitempty"`
+	RelayUDPEndpoint string     `json:"relayUDPEndpoint,omitempty"`
+	RelayUDP         bool       `json:"relayUDP"`
+	MeshCIDR         string     `json:"meshCIDR"`
+	NodeAddresses    string     `json:"nodeAddresses"`
+	Resources        []Resource `json:"resources"`
+	Impact           []string   `json:"infrastructureImpact"`
+	Warnings         []string   `json:"warnings,omitempty"`
+}
+
+type Inventory struct {
+	SchemaVersion   string     `json:"schemaVersion"`
+	InstallationID  string     `json:"installationID"`
+	InstalledAt     time.Time  `json:"installedAt"`
+	UpdatedAt       time.Time  `json:"updatedAt"`
+	WireKubeVersion string     `json:"wireKubeVersion"`
+	Image           string     `json:"image"`
+	Options         Options    `json:"options"`
+	Resources       []Resource `json:"resources"`
+}
+
+type Result struct {
+	SchemaVersion  string    `json:"schemaVersion"`
+	Operation      string    `json:"operation"`
+	InstallationID string    `json:"installationID,omitempty"`
+	Ready          bool      `json:"ready"`
+	Plan           Plan      `json:"plan"`
+	CompletedAt    time.Time `json:"completedAt"`
+}
+
+func (o *Options) Normalize() error {
+	if o.Namespace == "" {
+		o.Namespace = "wirekube-system"
+	}
+	if o.MeshCIDR == "" {
+		o.MeshCIDR = "auto"
+	}
+	if o.NodeAddresses == "" {
+		o.NodeAddresses = "mesh-only"
+	}
+	if o.Relay == "" {
+		if o.Yes {
+			return fmt.Errorf("--relay must be specified when --yes is used")
+		}
+		o.Relay = RelayLoadBalancer
+	}
+	switch o.Relay {
+	case RelayNone, RelayLoadBalancer:
+		if o.RelayEndpoint != "" {
+			return fmt.Errorf("--relay-endpoint is not valid with --relay=%s", o.Relay)
+		}
+		if o.RelayUDPEndpoint != "" {
+			return fmt.Errorf("--relay-udp-endpoint is not valid with --relay=%s", o.Relay)
+		}
+	case RelayNodePort, RelayExternal:
+		if strings.TrimSpace(o.RelayEndpoint) == "" {
+			return fmt.Errorf("--relay-endpoint is required with --relay=%s", o.Relay)
+		}
+		if err := validateEndpoint("--relay-endpoint", o.RelayEndpoint); err != nil {
+			return err
+		}
+		_, port, _ := net.SplitHostPort(o.RelayEndpoint)
+		if o.Relay == RelayNodePort && port != "30478" {
+			return fmt.Errorf("--relay=node-port currently requires endpoint port 30478")
+		}
+		if o.Relay == RelayNodePort && o.RelayUDPEndpoint != "" {
+			return fmt.Errorf("--relay-udp-endpoint is derived from --relay-endpoint with --relay=node-port")
+		}
+		if o.Relay == RelayExternal && o.RelayUDPEndpoint != "" {
+			if err := validateEndpoint("--relay-udp-endpoint", o.RelayUDPEndpoint); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported relay mode %q", o.Relay)
+	}
+	if !digestPattern.MatchString(o.Image) {
+		return fmt.Errorf("--image must be pinned by digest (IMAGE@sha256:DIGEST)")
+	}
+	if o.RelayUDP && o.Relay != RelayLoadBalancer && o.Relay != RelayNodePort {
+		return fmt.Errorf("--relay-udp is supported only with load-balancer or node-port relay provisioning")
+	}
+	switch o.NodeAddresses {
+	case "mesh-only", "internal-ip":
+	default:
+		return fmt.Errorf("unsupported --node-addresses value %q", o.NodeAddresses)
+	}
+	return nil
+}
+
+func validateEndpoint(flag, value string) error {
+	host, port, err := net.SplitHostPort(value)
+	if err != nil {
+		return fmt.Errorf("invalid %s %q: %w", flag, value, err)
+	}
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("invalid %s %q: host is empty", flag, value)
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return fmt.Errorf("invalid %s %q: port must be between 1 and 65535", flag, value)
+	}
+	return nil
+}

--- a/internal/kubeconfig/factory.go
+++ b/internal/kubeconfig/factory.go
@@ -1,0 +1,93 @@
+package kubeconfig
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Options struct {
+	Kubeconfig string
+	Context    string
+	Namespace  string
+	Timeout    time.Duration
+}
+
+type Factory struct {
+	options Options
+	scheme  *runtime.Scheme
+}
+
+func New(options Options, scheme *runtime.Scheme) *Factory {
+	return &Factory{options: options, scheme: scheme}
+}
+
+func (f *Factory) RESTConfig() (*rest.Config, error) {
+	config, err := f.clientConfig().ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load Kubernetes configuration: %w", err)
+	}
+	config.Timeout = f.options.Timeout
+	return config, nil
+}
+
+func (f *Factory) Client() (client.Client, error) {
+	config, err := f.RESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.New(config, client.Options{Scheme: f.scheme})
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes client: %w", err)
+	}
+	return c, nil
+}
+
+func (f *Factory) Discovery() (discovery.DiscoveryInterface, error) {
+	config, err := f.RESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("create Kubernetes discovery client: %w", err)
+	}
+	return c, nil
+}
+
+func (f *Factory) RawConfig() (clientcmdapi.Config, error) {
+	config, err := f.clientConfig().RawConfig()
+	if err != nil {
+		return clientcmdapi.Config{}, fmt.Errorf("load kubeconfig: %w", err)
+	}
+	return config, nil
+}
+
+func (f *Factory) Namespace() (string, error) {
+	if f.options.Namespace != "" {
+		return f.options.Namespace, nil
+	}
+	namespace, _, err := f.clientConfig().Namespace()
+	if err != nil {
+		return "", fmt.Errorf("resolve Kubernetes namespace: %w", err)
+	}
+	return namespace, nil
+}
+
+func (f *Factory) clientConfig() clientcmd.ClientConfig {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if f.options.Kubeconfig != "" {
+		loadingRules.ExplicitPath = f.options.Kubeconfig
+	}
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: f.options.Context}
+	if f.options.Namespace != "" {
+		overrides.Context.Namespace = f.options.Namespace
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
+}

--- a/internal/kubeconfig/factory_test.go
+++ b/internal/kubeconfig/factory_test.go
@@ -1,0 +1,84 @@
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestFactorySelectsExplicitContext(t *testing.T) {
+	path := writeKubeconfig(t)
+	factory := New(Options{
+		Kubeconfig: path,
+		Context:    "secondary",
+		Timeout:    17 * time.Second,
+	}, runtime.NewScheme())
+
+	config, err := factory.RESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Host != "https://secondary.example.test" {
+		t.Fatalf("host=%q", config.Host)
+	}
+	if config.Timeout != 17*time.Second {
+		t.Fatalf("timeout=%s", config.Timeout)
+	}
+	namespace, err := factory.Namespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if namespace != "secondary-ns" {
+		t.Fatalf("namespace=%q", namespace)
+	}
+}
+
+func TestFactoryReportsMissingContext(t *testing.T) {
+	factory := New(Options{
+		Kubeconfig: writeKubeconfig(t),
+		Context:    "missing",
+	}, runtime.NewScheme())
+
+	_, err := factory.RESTConfig()
+	if err == nil || !strings.Contains(err.Error(), `context "missing" does not exist`) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func writeKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	data := []byte(`apiVersion: v1
+kind: Config
+clusters:
+  - name: primary
+    cluster:
+      server: https://primary.example.test
+  - name: secondary
+    cluster:
+      server: https://secondary.example.test
+contexts:
+  - name: primary
+    context:
+      cluster: primary
+      user: user
+  - name: secondary
+    context:
+      cluster: secondary
+      namespace: secondary-ns
+      user: user
+current-context: primary
+users:
+  - name: user
+    user:
+      token: test
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,24 @@
+package version
+
+type Info struct {
+	Version      string `json:"version"`
+	Commit       string `json:"commit"`
+	BuildDate    string `json:"buildDate"`
+	DefaultImage string `json:"defaultImage,omitempty"`
+}
+
+var (
+	Version      = "dev"
+	Commit       = "unknown"
+	BuildDate    = "unknown"
+	DefaultImage = ""
+)
+
+func Current() Info {
+	return Info{
+		Version:      Version,
+		Commit:       Commit,
+		BuildDate:    BuildDate,
+		DefaultImage: DefaultImage,
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -17,12 +17,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/wirekube/wirekube/pkg/agent/nat"
-	agentrelay "github.com/wirekube/wirekube/pkg/agent/relay"
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/meship"
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	"github.com/inerplat/wirekube/pkg/agent/nat"
+	agentrelay "github.com/inerplat/wirekube/pkg/agent/relay"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/meship"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 // Agent is the per-node WireKube daemon.
@@ -1383,7 +1383,12 @@ func (a *Agent) driveTransportMode(
 		if peer == nil || peer.Spec.PublicKey == "" {
 			continue
 		}
-		mode := a.pathMonitor.Evaluate(name, peer.Spec.PublicKey, false)
+		var mode PathMode
+		if a.relayMode == relayModeAlways {
+			mode = a.pathMonitor.ForceRelay(name, peer.Spec.PublicKey)
+		} else {
+			mode = a.pathMonitor.Evaluate(name, peer.Spec.PublicKey, false)
+		}
 		directAddr := peer.Spec.Endpoint
 		if ep, ok := a.directEndpoints[name]; ok && ep != "" {
 			directAddr = ep

--- a/pkg/agent/birthday_test.go
+++ b/pkg/agent/birthday_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // newTestProxy builds a holePunchProxy backed by real loopback UDP sockets but

--- a/pkg/agent/endpoint.go
+++ b/pkg/agent/endpoint.go
@@ -12,7 +12,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/wirekube/wirekube/pkg/agent/nat"
+	"github.com/inerplat/wirekube/pkg/agent/nat"
 )
 
 // DiscoveryMethod records how an endpoint was found.

--- a/pkg/agent/gateway.go
+++ b/pkg/agent/gateway.go
@@ -11,7 +11,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // gatewayState tracks gateway configuration applied to this node.

--- a/pkg/agent/ice.go
+++ b/pkg/agent/ice.go
@@ -12,9 +12,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/wirekube/wirekube/pkg/agent/nat"
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	"github.com/inerplat/wirekube/pkg/agent/nat"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/agent/ice_test.go
+++ b/pkg/agent/ice_test.go
@@ -13,10 +13,10 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/wirekube/wirekube/pkg/agent/nat"
-	agentrelay "github.com/wirekube/wirekube/pkg/agent/relay"
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	"github.com/inerplat/wirekube/pkg/agent/nat"
+	agentrelay "github.com/inerplat/wirekube/pkg/agent/relay"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 type fakeWGEngine struct {

--- a/pkg/agent/metrics.go
+++ b/pkg/agent/metrics.go
@@ -11,8 +11,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 var (

--- a/pkg/agent/nat_reclassify_test.go
+++ b/pkg/agent/nat_reclassify_test.go
@@ -13,8 +13,8 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/wirekube/wirekube/pkg/agent/nat"
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/agent/nat"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestClassificationFromSTUN(t *testing.T) {

--- a/pkg/agent/path_monitor.go
+++ b/pkg/agent/path_monitor.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 // PathMode is the agent-owned transport mode for a single peer. It mirrors
@@ -210,6 +210,33 @@ func (m *PathMonitor) Forget(peerName string) {
 	m.mu.Lock()
 	delete(m.entries, peerName)
 	m.mu.Unlock()
+}
+
+// ForceRelay makes relay the authoritative path without permanently disabling
+// future direct probes. Callers may invoke it on every sync while an external
+// policy such as relay.mode=always is active.
+func (m *PathMonitor) ForceRelay(peerName, pubKey string) PathMode {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	lastDirect := m.rx.LastDirectReceive(pubKey)
+	e, ok := m.entries[peerName]
+	if !ok {
+		e = &pathEntry{
+			modeEnteredAt: now,
+		}
+		m.entries[peerName] = e
+	}
+	e.pubKey = pubKey
+	e.lastDirectSeen = lastDirect
+	e.lastProbeAt = now
+	if e.mode != PathModeRelay {
+		prev := e.mode
+		e.setMode(PathModeRelay, now)
+		m.log.Info("path monitor: relay forced", "peer", peerName, "from", prev)
+	}
+	return e.mode
 }
 
 // MarkNeverDirect pins a peer to PathModeRelay and suppresses subsequent

--- a/pkg/agent/path_monitor_test.go
+++ b/pkg/agent/path_monitor_test.go
@@ -177,6 +177,36 @@ func TestForgetClearsEntry(t *testing.T) {
 	}
 }
 
+func TestForceRelayOverridesDirectWithoutDisablingFutureProbes(t *testing.T) {
+	pm, rx, clk := newMonitor(t)
+	pm.Evaluate("p1", "key1", true)
+	clk.advance(10 * time.Millisecond)
+	rx.last["key1"] = clk.now().UnixNano()
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeDirect {
+		t.Fatalf("setup: want Direct, got %v", got)
+	}
+
+	if got := pm.ForceRelay("p1", "key1"); got != PathModeRelay {
+		t.Fatalf("ForceRelay from Direct = %v, want PathModeRelay", got)
+	}
+	if got := pm.ModeFor("p1"); got != PathModeRelay {
+		t.Fatalf("ModeFor after ForceRelay = %v, want PathModeRelay", got)
+	}
+
+	clk.advance(100 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeRelay {
+		t.Fatalf("Evaluate before relay retry = %v, want PathModeRelay", got)
+	}
+	clk.advance(150 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("Evaluate after relay retry = %v, want PathModeWarm", got)
+	}
+	clk.advance(10 * time.Millisecond)
+	if got := pm.Evaluate("p1", "key1", false); got != PathModeWarm {
+		t.Fatalf("stale direct watermark after ForceRelay = %v, want PathModeWarm", got)
+	}
+}
+
 // TestStaleWatermarkIsNotFreshEvidence asserts that an RX watermark
 // captured before the peer entered Warm (e.g. from a previous Direct
 // session whose evidence the monitor already consumed) does not promote.

--- a/pkg/agent/peer_cleanup_test.go
+++ b/pkg/agent/peer_cleanup_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func cleanupTestScheme(t *testing.T) *runtime.Scheme {

--- a/pkg/agent/relay/client.go
+++ b/pkg/agent/relay/client.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 var clientDebug = os.Getenv("WIREKUBE_BIND_DEBUG") == "1"

--- a/pkg/agent/relay/dial.go
+++ b/pkg/agent/relay/dial.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gorilla/websocket"
 	"golang.org/x/net/http/httpproxy"
 
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 var relayProxyFromEnvironment = proxyURLFromEnvironment

--- a/pkg/agent/relay/pool.go
+++ b/pkg/agent/relay/pool.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 // Pool manages connections to multiple relay server instances.

--- a/pkg/agent/relay/proxy.go
+++ b/pkg/agent/relay/proxy.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 // Sender can deliver a UDP payload to a remote peer via the relay network.

--- a/pkg/agent/relay_proxy_test.go
+++ b/pkg/agent/relay_proxy_test.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	agentrelay "github.com/wirekube/wirekube/pkg/agent/relay"
+	agentrelay "github.com/inerplat/wirekube/pkg/agent/relay"
 )
 
 func TestRelayProxyModeFromNodeAnnotation(t *testing.T) {

--- a/pkg/agent/relay_transport_test.go
+++ b/pkg/agent/relay_transport_test.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"testing"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestExternalRelayDialConfigDefaultsToTCP(t *testing.T) {

--- a/pkg/agent/route_filter_test.go
+++ b/pkg/agent/route_filter_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/wirekube/wirekube/pkg/wireguard"
+	"github.com/inerplat/wirekube/pkg/wireguard"
 )
 
 func TestFilterRoutesForConnectedPeersKeepsRelayBootstrapRoutes(t *testing.T) {

--- a/pkg/api/v1alpha1/wirekubemesh_types.go
+++ b/pkg/api/v1alpha1/wirekubemesh_types.go
@@ -127,7 +127,7 @@ type RelaySpec struct {
 
 	// Provider selects how the relay server is provisioned.
 	// "external": user provides a pre-existing relay endpoint (public IP server, third-party).
-	// "managed": operator deploys and manages the relay as a Pod + LoadBalancer Service.
+	// "managed": the installation owner provisions the relay resources and agents use the cluster-local control Service.
 	// +kubebuilder:validation:Enum=external;managed
 	Provider string `json:"provider"`
 
@@ -157,9 +157,11 @@ type RelaySpec struct {
 
 // ExternalRelaySpec configures a user-provided relay server.
 type ExternalRelaySpec struct {
-	// Endpoint is the relay server address (host:port).
+	// Endpoint is the raw WireGuard UDP address advertised to external peers.
 	// Example: "relay.example.com:3478" or "203.0.113.10:3478"
-	Endpoint string `json:"endpoint"`
+	// Leave empty when no UDP entrypoint is available; external peers remain Pending.
+	// +optional
+	Endpoint string `json:"endpoint,omitempty"`
 
 	// ControlEndpoint is the agent-facing relay endpoint. It is required for
 	// ws/wss transport and may hold a separate raw TCP address for tcp transport.
@@ -179,7 +181,7 @@ type ExternalRelaySpec struct {
 	AuthSecretRef *SecretKeyRef `json:"authSecretRef,omitempty"`
 }
 
-// ManagedRelaySpec configures the operator-managed relay.
+// ManagedRelaySpec configures a relay provisioned alongside the WireKube installation.
 type ManagedRelaySpec struct {
 	// Replicas is the number of relay pod replicas.
 	// +kubebuilder:default=1

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -12,7 +12,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // WireKubeMeshReconciler reconciles WireKubeMesh objects.

--- a/pkg/controller/external/reconciler.go
+++ b/pkg/controller/external/reconciler.go
@@ -17,8 +17,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/meship"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/meship"
 )
 
 // FinalizerName is added to every WireKubeExternalPeer the reconciler owns so

--- a/pkg/controller/external/reconciler_test.go
+++ b/pkg/controller/external/reconciler_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // ---------------------------------------------------------------------------

--- a/pkg/controller/external/relay_controller.go
+++ b/pkg/controller/external/relay_controller.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wirekube/wirekube/pkg/relay"
-	"github.com/wirekube/wirekube/pkg/relay/portalloc"
+	"github.com/inerplat/wirekube/pkg/relay"
+	"github.com/inerplat/wirekube/pkg/relay/portalloc"
 )
 
 // ErrNotImplemented is returned by the noop RelayController for legacy

--- a/pkg/controller/external/relay_controller_test.go
+++ b/pkg/controller/external/relay_controller_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wirekube/wirekube/pkg/relay"
-	"github.com/wirekube/wirekube/pkg/relay/portalloc"
+	"github.com/inerplat/wirekube/pkg/relay"
+	"github.com/inerplat/wirekube/pkg/relay/portalloc"
 )
 
 // pickRange returns a small allocator range that does not collide with

--- a/pkg/controller/external/remote_relay_controller.go
+++ b/pkg/controller/external/remote_relay_controller.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wirekube/wirekube/pkg/relay"
+	"github.com/inerplat/wirekube/pkg/relay"
 )
 
 // RemoteRelayController is a RelayController that talks to a relay over

--- a/pkg/externalpeer/config.go
+++ b/pkg/externalpeer/config.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // WaitForActive polls a WireKubeExternalPeer until the reconciler has rendered

--- a/pkg/relay/forwarder_test.go
+++ b/pkg/relay/forwarder_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/wirekube/wirekube/pkg/relay/portalloc"
+	"github.com/inerplat/wirekube/pkg/relay/portalloc"
 )
 
 // recordingDispatcher captures every Dispatch call. Tests assert on the

--- a/pkg/relay/server.go
+++ b/pkg/relay/server.go
@@ -15,7 +15,7 @@ import (
 
 	"golang.org/x/time/rate"
 
-	"github.com/wirekube/wirekube/pkg/relay/portalloc"
+	"github.com/inerplat/wirekube/pkg/relay/portalloc"
 )
 
 var relayDebug = os.Getenv("WIREKUBE_RELAY_DEBUG") == "1"

--- a/pkg/relay/wsgateway/auth.go
+++ b/pkg/relay/wsgateway/auth.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 const serviceAccountUsernamePrefix = "system:serviceaccount:"

--- a/pkg/relay/wsgateway/auth_test.go
+++ b/pkg/relay/wsgateway/auth_test.go
@@ -14,7 +14,7 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	controllerfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestAuthenticatePodBoundAgent(t *testing.T) {

--- a/pkg/relay/wsgateway/server.go
+++ b/pkg/relay/wsgateway/server.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	relayproto "github.com/wirekube/wirekube/pkg/relay"
+	relayproto "github.com/inerplat/wirekube/pkg/relay"
 )
 
 type Server struct {

--- a/pkg/wireguard/bind.go
+++ b/pkg/wireguard/bind.go
@@ -700,8 +700,8 @@ func (b *WireKubeBind) makeRelayReceiveFunc() conn.ReceiveFunc {
 				dst = netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 0)
 			}
 			eps[0] = &WireKubeEndpoint{
-				dst:     dst,
-				peerKey: pkt.SrcKey,
+				dst:          dst,
+				relayPeerKey: relayPeerKey{peerKey: pkt.SrcKey},
 			}
 			return 1, nil
 		case <-b.relayClose:

--- a/pkg/wireguard/endpoint.go
+++ b/pkg/wireguard/endpoint.go
@@ -14,8 +14,8 @@ var _ conn.Endpoint = (*WireKubeEndpoint)(nil)
 // When peerKey is set (relay-received packets), Send() uses it directly to look
 // up the pathTable instead of going through the addrToPeer reverse map.
 type WireKubeEndpoint struct {
-	dst            netip.AddrPort
-	peerKey        [32]byte // set by relay ReceiveFunc; zero value means unset
+	dst netip.AddrPort
+	relayPeerKey
 	externalSource ExternalSource
 }
 
@@ -43,6 +43,9 @@ func (e *WireKubeEndpoint) DstToString() string {
 // DstToBytes returns the binary representation of the destination address,
 // used by wireguard-go for mac2 cookie calculations.
 func (e *WireKubeEndpoint) DstToBytes() []byte {
+	if e.relayPeerKeySet() && !e.dst.IsValid() {
+		return nil
+	}
 	b, _ := e.dst.MarshalBinary()
 	return b
 }

--- a/pkg/wireguard/endpoint_peerkey_linux.go
+++ b/pkg/wireguard/endpoint_peerkey_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package wireguard
+
+type relayPeerKey struct {
+	peerKey [32]byte
+}
+
+func (k relayPeerKey) relayPeerKeySet() bool {
+	return k.peerKey != [32]byte{}
+}

--- a/pkg/wireguard/endpoint_peerkey_unsupported.go
+++ b/pkg/wireguard/endpoint_peerkey_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package wireguard
+
+type relayPeerKey struct{}
+
+func (relayPeerKey) relayPeerKeySet() bool {
+	return false
+}

--- a/test/e2e/mesh_test.go
+++ b/test/e2e/mesh_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestMeshReconciler_DefaultsApplied(t *testing.T) {

--- a/test/e2e/peer_test.go
+++ b/test/e2e/peer_test.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestPeer_CreateAndGet(t *testing.T) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -28,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
-	"github.com/wirekube/wirekube/pkg/controller"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
+	"github.com/inerplat/wirekube/pkg/controller"
 )
 
 var (

--- a/test/kind_e2e/infra_test.go
+++ b/test/kind_e2e/infra_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 // ── Container runtime ────────────────────────────────────────────────────────
@@ -1395,6 +1395,11 @@ spec:
             - --path=/relay
             - --tls-cert-file=/var/run/wirekube-relay-tls/tls.crt
             - --tls-private-key-file=/var/run/wirekube-relay-tls/tls.key
+          env:
+            - name: KUBERNETES_SERVICE_HOST
+              value: "%[3]s"
+            - name: KUBERNETES_SERVICE_PORT
+              value: "6443"
           readinessProbe:
             httpGet:
               scheme: HTTPS
@@ -1410,7 +1415,7 @@ spec:
         - name: relay-tls
           secret:
             secretName: wirekube-relay-e2e-tls
-`, agentNamespace, image)
+`, agentNamespace, image, cpNode().ip)
 
 	tmp, err := os.CreateTemp("", "wk-relay-wss-*.yaml")
 	if err != nil {
@@ -1718,40 +1723,5 @@ func patchMeshRelayMode(ctx context.Context, t *testing.T, newMode string) func(
 		if err := k8sClient.Patch(rctx, &m, p); err != nil {
 			t.Logf("warning: restore relay.mode=%q: %v", originalMode, err)
 		}
-	}
-}
-
-func relayEndpointFromMesh(ctx context.Context, t *testing.T) string {
-	t.Helper()
-	var mesh wirekubev1alpha1.WireKubeMesh
-	if err := k8sClient.Get(ctx, types.NamespacedName{Name: meshName}, &mesh); err != nil {
-		t.Fatalf("get WireKubeMesh: %v", err)
-	}
-	if mesh.Spec.Relay != nil && mesh.Spec.Relay.External != nil {
-		return mesh.Spec.Relay.External.Endpoint
-	}
-	return ""
-}
-
-func setRelayEndpoint(ctx context.Context, t *testing.T, endpoint string) {
-	t.Helper()
-	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	var mesh wirekubev1alpha1.WireKubeMesh
-	if err := k8sClient.Get(tctx, types.NamespacedName{Name: meshName}, &mesh); err != nil {
-		t.Logf("warning: get WireKubeMesh: %v", err)
-		return
-	}
-	p := client.MergeFrom(mesh.DeepCopy())
-	if mesh.Spec.Relay == nil {
-		mesh.Spec.Relay = &wirekubev1alpha1.RelaySpec{}
-	}
-	if mesh.Spec.Relay.External == nil {
-		mesh.Spec.Relay.External = &wirekubev1alpha1.ExternalRelaySpec{}
-	}
-	mesh.Spec.Relay.External.Endpoint = endpoint
-	if err := k8sClient.Patch(tctx, &mesh, p); err != nil {
-		t.Logf("warning: patch relay endpoint to %s: %v", endpoint, err)
 	}
 }

--- a/test/kind_e2e/peers_test.go
+++ b/test/kind_e2e/peers_test.go
@@ -12,7 +12,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func allPeers(ctx context.Context, t *testing.T) []string {

--- a/test/kind_e2e/suite_test.go
+++ b/test/kind_e2e/suite_test.go
@@ -53,7 +53,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 const (

--- a/test/kind_e2e/transport_test.go
+++ b/test/kind_e2e/transport_test.go
@@ -12,8 +12,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	wirekubev1alpha1 "github.com/wirekube/wirekube/pkg/api/v1alpha1"
+	wirekubev1alpha1 "github.com/inerplat/wirekube/pkg/api/v1alpha1"
 )
 
 func TestRelayTransportConfigured(t *testing.T) {
@@ -48,6 +49,86 @@ func TestRelayTransportConfigured(t *testing.T) {
 		}
 		return deployment.Status.ReadyReplicas == 1
 	}, 2*time.Minute, pollInterval, "WSS relay gateway should be ready")
+
+	peers := waitForPeers(ctx, t, len(nodeConfigs))
+	restoreMode := patchMeshRelayMode(ctx, t, "always")
+	defer restoreMode()
+	waitForRelayDataPlane(ctx, t, peers[0], peers[1], relayTimeout)
+}
+
+func waitForRelayDataPlane(ctx context.Context, t *testing.T, subject, remote string, timeout time.Duration) {
+	t.Helper()
+	remoteIP := nodeIPForPeer(t, remote)
+
+	eventually(t, func() bool {
+		mode := connectionMode(ctx, t, subject, remote)
+		if mode != "relay" {
+			t.Logf("%s → %s = %q, waiting for relay", subject, remote, mode)
+			return false
+		}
+
+		pod := agentPodForNode(ctx, t, subject)
+		out, err := execInPod(ctx, t, pod, "agent", []string{"ping", "-c", "2", "-W", "2", remoteIP})
+		if err != nil {
+			t.Logf("relay ping %s→%s: %v (%s)", subject, remote, err, out)
+			return false
+		}
+		t.Logf("relay data plane %s→%s is healthy", subject, remote)
+		return true
+	}, timeout, pollInterval, subject+" → "+remote+" should pass traffic over relay")
+}
+
+func relayEntrypointDeployment() string {
+	if relayTransport() == relayTransportWSS {
+		return "wirekube-relay-ws"
+	}
+	return "wirekube-relay"
+}
+
+func scaleRelayEntrypoint(ctx context.Context, t *testing.T, replicas int32) func() {
+	t.Helper()
+	name := relayEntrypointDeployment()
+	key := types.NamespacedName{Namespace: agentNamespace, Name: name}
+
+	var deployment appsv1.Deployment
+	if err := k8sClient.Get(ctx, key, &deployment); err != nil {
+		t.Fatalf("get relay entrypoint deployment %s: %v", name, err)
+	}
+	originalReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		originalReplicas = *deployment.Spec.Replicas
+	}
+
+	setReplicas := func(value int32) error {
+		var current appsv1.Deployment
+		if err := k8sClient.Get(ctx, key, &current); err != nil {
+			return err
+		}
+		patch := client.MergeFrom(current.DeepCopy())
+		current.Spec.Replicas = &value
+		return k8sClient.Patch(ctx, &current, patch)
+	}
+	if err := setReplicas(replicas); err != nil {
+		t.Fatalf("scale relay entrypoint deployment %s to %d: %v", name, replicas, err)
+	}
+
+	eventually(t, func() bool {
+		var current appsv1.Deployment
+		if err := k8sClient.Get(ctx, key, &current); err != nil {
+			t.Logf("get relay entrypoint deployment %s: %v", name, err)
+			return false
+		}
+		if replicas == 0 {
+			return current.Status.Replicas == 0
+		}
+		return current.Status.ReadyReplicas == replicas
+	}, 2*time.Minute, pollInterval, fmt.Sprintf("relay entrypoint deployment %s should have %d ready replicas", name, replicas))
+
+	return func() {
+		if err := setReplicas(originalReplicas); err != nil {
+			t.Logf("warning: restore relay entrypoint deployment %s to %d replicas: %v", name, originalReplicas, err)
+		}
+	}
 }
 
 func resetTransportState(ctx context.Context, t *testing.T) []string {
@@ -664,29 +745,27 @@ func TestRelayReconnect(t *testing.T) {
 
 	restoreMode := patchMeshRelayMode(ctx, t, "always")
 	defer restoreMode()
+	waitForRelayDataPlane(ctx, t, subject, remote, relayTimeout)
+	unblock := blockWireGuardUDP(t, subject)
+	defer unblock()
 
-	eventually(t, func() bool {
-		return connectionMode(ctx, t, subject, remote) == "relay"
-	}, relayTimeout, pollInterval, subject+" → "+remote+" should be relay")
-
-	original := relayEndpointFromMesh(ctx, t)
-	if original == "" {
-		t.Skip("no external relay endpoint")
-	}
-
-	setRelayEndpoint(ctx, t, "127.0.0.1:19999")
-	defer setRelayEndpoint(ctx, t, original)
+	restoreEntrypoint := scaleRelayEntrypoint(ctx, t, 0)
+	defer restoreEntrypoint()
 
 	t.Log("relay broken — waiting 15s…")
 	time.Sleep(15 * time.Second)
 
-	setRelayEndpoint(ctx, t, original)
-
+	restoreEntrypoint()
 	eventually(t, func() bool {
-		mode := connectionMode(ctx, t, subject, remote)
-		t.Logf("%s → %s = %q", subject, remote, mode)
-		return mode == "relay" || mode == "direct"
-	}, 3*time.Minute, pollInterval, "should recover after relay restore")
+		var deployment appsv1.Deployment
+		name := relayEntrypointDeployment()
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: agentNamespace, Name: name}, &deployment); err != nil {
+			t.Logf("get relay entrypoint deployment %s: %v", name, err)
+			return false
+		}
+		return deployment.Status.ReadyReplicas == 1
+	}, 2*time.Minute, pollInterval, "relay entrypoint should become ready after restore")
+	waitForRelayDataPlane(ctx, t, subject, remote, 3*time.Minute)
 	t.Log("relay reconnect recovery confirmed")
 
 	restoreMode()


### PR DESCRIPTION
## What changed

- add `wirekubectl install`, `manifest`, `upgrade`, `status`, `doctor`, and inventory-based `uninstall`
- support kubeconfig, context, namespace, JSON output, dry-run, immutable image digests, and release metadata
- gate release publishing on lint, unit tests, build, and the TCP/WSS kind E2E matrix
- enforce one WireKube installation per cluster and stamp managed resources with an installation ID
- restore previous objects, inventory, and stale resources when an upgrade fails
- separate relay TCP control endpoints from raw WireGuard UDP endpoints so TCP-only installs keep external peers Pending
- require an explicit mesh CIDR for non-interactive installation and add SelfSubjectAccessReview permission checks
- report component rollout and mesh connectivity separately; make `doctor` probe relay TCP reachability and exit non-zero on failures
- align the Go module path and release ldflags with `github.com/inerplat/wirekube`

## Why

The repository manifests required a source checkout and left installation topology, release/image matching, upgrades, and safe removal to the operator. The initial lifecycle implementation also allowed namespace inventories to contend for cluster-scoped RBAC, could advertise a TCP LoadBalancer as a WireGuard UDP endpoint, and did not restore updated resources after a failed upgrade.

This change makes the released CLI the primary installation contract while preserving explicit plans, immutable artifacts, ownership boundaries, and rollback behavior.

## Validation

- `go test $(go list ./... | rg -v '/test/e2e$') -count=1`
- `go test -race ./internal/install -count=1`
- `go vet ./...`
- `golangci-lint run ./...`
- kind E2E test binary compilation
- Linux WireGuard package compilation
- darwin/linux x amd64/arm64 release-style `wirekubectl` builds
- `go mod tidy -diff`
- `git diff --check`

Live-cluster mutation was not used for this change.
