### PR TITLE
docs: add Homebrew installation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ No coordination server, no external etcd, no control plane beyond the Kubernetes
 ## Quick Start
 
 ```bash
-# Download a wirekubectl binary from the GitHub Release for your platform,
-# verify it with wirekubectl-checksums.txt, and place it on PATH.
+brew install inerplat/tap/wirekube
+wirekubectl version
+
 wirekubectl install --kubeconfig ~/.kube/config --context my-cluster
 wirekubectl status
 ```
+
+The Homebrew formula supports macOS and Linux on ARM64 and AMD64. GitHub
+Release binaries with a checksum file remain available for environments that
+do not use Homebrew.
 
 The installer inspects the cluster and shows the exact CRDs, privileged workloads, relay infrastructure, image digest, and mesh CIDR before mutation. Automation must select the relay topology and mesh CIDR explicitly, for example `wirekubectl install --relay load-balancer --mesh-cidr 100.96.0.0/11 --yes --output json`. LoadBalancer installs create separate TCP and UDP entry points by default; use `--relay-transport wss --relay-endpoint wss://relay.example.com/relay` when an existing HTTPS Gateway or Ingress must front the authenticated WebSocket relay backend.
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -64,6 +64,26 @@ docker push inerplat/wirekube:latest
 
 Tag builds run formatting, vet, lint, unit tests, and the TCP/WSS disposable-cluster E2E matrix before publishing anything. After those gates pass, the workflow publishes the multi-architecture image, builds four standalone `wirekubectl` binaries, injects the version, commit, build date, and immutable image digest, and creates a GitHub Release with SHA256 checksums.
 
+### Homebrew tap
+
+The public formula lives in
+[`inerplat/homebrew-tap`](https://github.com/inerplat/homebrew-tap) as
+`Formula/wirekube.rb`. After publishing a WireKube release, update the formula's
+version, four platform URLs, and four SHA-256 values from
+`wirekubectl-checksums.txt`, then verify it on a clean tap checkout:
+
+```bash
+brew style inerplat/tap/wirekube
+brew audit --strict inerplat/tap/wirekube
+brew install inerplat/tap/wirekube
+brew test inerplat/tap/wirekube
+wirekubectl version
+```
+
+Do not point the formula at `latest`, a mutable container tag, or an unverified
+binary. The released CLI embeds the matching immutable WireKube container image
+digest used by `wirekubectl install` and `wirekubectl upgrade`.
+
 ## Dockerfile
 
 The multi-stage Dockerfile:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,37 @@
 # Installation
 
-## Install with wirekubectl
+## Install with Homebrew
+
+The public tap installs `wirekubectl` on macOS or Linux, on ARM64 or AMD64:
+
+```bash
+brew install inerplat/tap/wirekube
+wirekubectl version
+```
+
+The formula installs only the client. It does not modify a Kubernetes cluster.
+Run a dry run before approving the cluster-wide CRDs, privileged agent, and
+relay topology:
+
+```bash
+wirekubectl install --dry-run \
+  --kubeconfig ~/.kube/config \
+  --context my-cluster
+
+wirekubectl install \
+  --kubeconfig ~/.kube/config \
+  --context my-cluster
+```
+
+Upgrade the CLI independently from the installed cluster resources, then run
+the explicit WireKube upgrade command:
+
+```bash
+brew upgrade inerplat/tap/wirekube
+wirekubectl upgrade --kubeconfig ~/.kube/config --context my-cluster
+```
+
+## Install from a GitHub Release
 
 Release assets contain standalone `wirekubectl` binaries for macOS and Linux on AMD64 and ARM64. Download the binary and checksum file for the version you want from the [GitHub Releases](https://github.com/inerplat/wirekube/releases) page, verify the checksum, and place the binary on your `PATH`. Each release also includes `wirekube-release.json` with the immutable container image digest embedded in that CLI.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,138 +1,138 @@
 # Quick Start
 
-Get WireKube running on your Kubernetes cluster in 5 minutes.
+This path installs WireKube from a released `wirekubectl` binary without a
+source checkout. It does not assume a specific cloud provider or CNI.
 
 ## Prerequisites
 
 | Requirement | Minimum |
-|-------------|---------|
+| --- | --- |
 | Kubernetes | 1.26+ |
-| Linux Kernel | 5.6+ (built-in WireGuard) |
-| `kubectl` access | Cluster admin |
+| Linux kernel on participating nodes | 5.6+ |
+| Cluster access | Permission to create cluster-scoped CRDs and RBAC |
+| Local tools | Homebrew and a reachable kubeconfig |
 
-## Step 1: Install CRDs
-
-```bash
-kubectl apply -f config/crd/
-```
-
-This creates four Custom Resource Definitions:
-
-- **WireKubeMesh** — Global mesh configuration (listen port, STUN servers, relay settings)
-- **WireKubePeer** — Per-node peer state (auto-managed by the agent)
-- **WireKubeGateway** — Virtual gateway routes and failover configuration
-- **WireKubeExternalPeer** — Off-cluster WireGuard client authorization and status
-
-## Step 2: Create a Mesh
+## Install the CLI
 
 ```bash
-kubectl apply -f config/examples/wirekubemesh-basic.yaml
+brew install inerplat/tap/wirekube
+wirekubectl version
 ```
 
-Or create a custom mesh configuration:
+Homebrew supports macOS and Linux on ARM64 and AMD64. Use the checksum-verified
+GitHub Release path in the [installation guide](installation.md) when Homebrew
+is unavailable.
 
-```yaml
-apiVersion: wirekube.io/v1alpha1
-kind: WireKubeMesh
-metadata:
-  name: default
-spec:
-  listenPort: 51820
-  interfaceName: wire_kube
-  mtu: 1420
-  stunServers:
-    - stun.cloudflare.com:3478
-    - stun.l.google.com:19302
-  relay:
-    mode: auto
-    provider: managed
-    handshakeTimeoutSeconds: 30
-    directRetryIntervalSeconds: 120
-    managed:
-      replicas: 1
-      serviceType: LoadBalancer
-      port: 3478
-```
+## Inspect the cluster
 
-!!! note "STUN Servers"
-    At least two STUN servers are required. The agent compares mapped ports
-    from multiple servers to detect Symmetric NAT (RFC 5780).
-
-!!! note "Relay"
-    If all nodes have public IPs or are in the same VPC, set `relay.mode: never`.
-    For cross-VPC or multi-cloud deployments, `auto` with a managed or external
-    relay is recommended.
-
-## Step 3: Deploy the Agent
+Set the kubeconfig and context once for the remaining commands:
 
 ```bash
-kubectl create namespace wirekube-system --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f config/agent/rbac.yaml
-kubectl apply -f config/agent/daemonset.yaml
+export WIREKUBE_KUBECONFIG="${HOME}/.kube/config"
+export WIREKUBE_CONTEXT=my-cluster
+
+kubectl --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}" \
+  get nodes -o wide
 ```
 
-The default agent DaemonSet runs on every node except nodes labeled `wirekube.io/proxy-node=true`. It uses `hostNetwork: true`, `dnsPolicy: Default`, userspace WireGuard, and a privileged security context for TUN access.
+Replace `my-cluster` before continuing.
 
-## Step 4: Choose Agent Placement
+## Choose a relay entry point
 
-The current default manifest does not use `wirekube.io/vpn-enabled=true` as a scheduling gate. To restrict participation, add your own node affinity or node selector to `config/agent/daemonset.yaml` before applying it.
+| Environment | Recommended choice |
+| --- | --- |
+| Cloud cluster with a reachable LoadBalancer | `--relay load-balancer` |
+| Reachable node address, no LoadBalancer | `--relay node-port` |
+| Existing HTTPS Gateway or Ingress | `--relay-transport wss` |
+| Existing separately operated relay | `--relay external` |
 
-## Step 5: (Optional) Deploy the Relay
+The managed LoadBalancer path is the simplest default, but it can create public
+TCP and UDP Services. Read the [relay entry point guide](../guides/relay-entrypoints.md)
+before selecting NodePort, WSS, or an external relay.
 
-For managed relay (in-cluster):
+## Preview the installation
+
+Interactive dry run performs discovery and prints the exact plan without
+creating resources:
 
 ```bash
-kubectl apply -f config/relay/deployment.yaml
-kubectl apply -f config/relay/example-managed.yaml
+wirekubectl install \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}" \
+  --dry-run
 ```
 
-The relay manifest currently contains an EKS-specific `eks.amazonaws.com/nodegroup: relay-ng` node selector. Remove or replace it before applying the manifest to another cluster.
+Review the selected mesh CIDR, immutable image digest, agent placement, relay
+Services, and any public entry points. Automatic CIDR selection is best effort;
+provide `--mesh-cidr` when the CLI cannot know every routed network.
 
-For external relay on a public server:
+## Install WireKube
+
+Run the same command without `--dry-run`. The interactive prompt is the final
+approval boundary:
 
 ```bash
-wirekube-relay --addr :3478
+wirekubectl install \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}"
 ```
 
-See [Relay Architecture](../architecture/relay.md) for details on relay modes and scaling. If your cluster cannot provision a public LoadBalancer, or some nodes use an HTTP CONNECT proxy, follow [Relay Entry Points](../guides/relay-entrypoints.md).
-
-## Step 6: Set AllowedIPs
-
-AllowedIPs are intentionally user-managed. Set each peer's node IP to enable routing:
+Automation must make infrastructure choices explicit:
 
 ```bash
-kubectl patch wirekubepeer <peer-name> --type=merge \
-  -p '{"spec":{"allowedIPs":["<node-ip>/32"]}}'
+wirekubectl install \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}" \
+  --relay load-balancer \
+  --mesh-cidr 100.96.0.0/11 \
+  --node-addresses internal-ip \
+  --yes \
+  --output json
 ```
 
-Without `allowedIPs`, the agent enters passive mode — no routes are added and
-no WireGuard traffic flows for that peer.
+Choose a private mesh CIDR that does not overlap node, Pod, Service, VPC, VPN,
+or corporate routes.
 
-## Step 7: Verify
+## Verify the mesh
 
 ```bash
-kubectl get wirekubepeers -o wide
-kubectl get wirekubemesh default -o yaml
+wirekubectl status \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}"
 
-# On any node
-wg show wire_kube
-ping <other-node-ip>
+wirekubectl doctor \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}"
+
+kubectl --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}" \
+  get wirekubemeshes,wirekubepeers -o wide
 ```
 
-## What Happens
+New peers may need time to publish endpoints and complete their first
+handshake. `wirekubectl doctor` distinguishes agent, relay, route, and readiness
+failures.
 
-1. Each agent creates a WireGuard interface (`wire_kube`) and generates a key pair
-2. The agent registers itself as a `WireKubePeer` CRD
-3. STUN queries two servers to discover the public endpoint and detect NAT type
-4. If mapped ports differ between STUN servers → Symmetric NAT detected
-5. When relay is configured, new peers start with relay availability while direct probing runs
-6. Healthy direct receive evidence promotes a peer to direct; failed or stale paths remain on relay
-7. Connected AllowedIPs are installed in routing table `22347`, selected by an IP rule at priority `200`
-8. The agent periodically re-probes relayed peers for direct connectivity
+## Lifecycle
 
-## Next Steps
+```bash
+wirekubectl upgrade \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}"
 
-- [Installation Guide](installation.md) — Detailed installation and build options
-- [Configuration](configuration.md) — All configuration fields explained
-- [NAT Traversal](../architecture/nat-traversal.md) — How WireKube handles NAT
-- [Relay Design](../architecture/relay.md) — Protocol, failover, and scaling
+wirekubectl uninstall \
+  --kubeconfig "${WIREKUBE_KUBECONFIG}" \
+  --context "${WIREKUBE_CONTEXT}"
+```
+
+Ordinary uninstall preserves CRDs and custom resources. Destructive removal
+requires both `--purge` and `--confirm-purge`; use it only after proving that no
+remaining node or external peer depends on WireKube.
+
+## Next steps
+
+- [Installation](installation.md): release binaries, topology details, and source builds
+- [Configuration](configuration.md): mesh and agent settings
+- [Relay entry points](../guides/relay-entrypoints.md): LoadBalancer, NodePort, WSS, and external relay
+- [Troubleshooting](../operations/troubleshooting.md): readiness and connectivity failures


### PR DESCRIPTION
## What changed

- make `brew install inerplat/tap/wirekube` the primary CLI installation path
- rewrite the quick start around the ownership-aware `wirekubectl install` flow
- document release-binary fallback, lifecycle commands, and Homebrew formula maintenance

## Why

WireKube now has a published multi-platform formula in `inerplat/homebrew-tap`.
Users should be able to install the released CLI without cloning the source
repository while still reviewing relay topology and cluster-wide mutations
before approval.

## Validation

- `mkdocs build --strict`
- `git diff --check`
- `brew style inerplat/tap/wirekube`
- `brew audit --strict inerplat/tap/wirekube`
- `brew install inerplat/tap/wirekube`
- `brew test inerplat/tap/wirekube`
